### PR TITLE
feat: fetch 호출을 /src/api 디렉토리로 제한하는 컨벤션 적용

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,4 +56,34 @@ A2. vscode로 커밋하는 경우 알럿팝업에서 "Open Git Log"나 "Show Com
 
 ### 코딩 규칙, 가이드라인, 개발 컨벤션
 
+#### API 호출 컨벤션
+
+- **fetch 호출은 `/src/api` 디렉토리 내에서만 허용됩니다.**
+- 컴포넌트, 훅, 페이지 등에서는 직접 fetch를 호출하지 말고 API 모듈을 사용하세요.
+- 새로운 API 엔드포인트가 필요한 경우 해당하는 API 파일에 함수를 추가하세요.
+
+**예시:**
+
+```typescript
+// ❌ 잘못된 방법 - 컴포넌트에서 직접 fetch 호출
+const handleSubmit = () => {
+  fetch('/api/v1/challenges/submit', {
+    method: 'POST',
+    body: formData,
+  })
+}
+
+// ✅ 올바른 방법 - API 모듈 사용
+import { challengesApi } from '@/api/challenges'
+
+const handleSubmit = () => {
+  challengesApi.submitChallenge(formData)
+}
+```
+
+**API 파일 구조:**
+
+- `/src/api/challenges.ts` - 챌린지 관련 API
+- `/src/api/users.ts` - 사용자 관련 API
+
 - 현재 특별한 규칙은 없습니다. 의견이 있는 경우에 이슈를 제기해주세요.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,6 +30,19 @@ export default tseslint.config(
           ignoreRestSiblings: true,
         },
       ],
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'CallExpression[callee.name="fetch"]',
+          message: 'fetch 호출은 /src/api 디렉토리 내에서만 허용됩니다. API 모듈을 사용해주세요.',
+        },
+      ],
+    },
+  },
+  {
+    files: ['src/api/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-syntax': 'off',
     },
   },
   eslintConfigPrettier,

--- a/src/api/challenges.ts
+++ b/src/api/challenges.ts
@@ -107,6 +107,20 @@ export const challengesApi = {
     }
     return
   },
+  submitIndividualChallenge: async (challengeId: string | undefined, body: FormData) => {
+    if (challengeId == null) {
+      throw new Error('challengeId is required')
+    }
+    const response = await fetch(`/api/v1/challenges/${challengeId}/submit`, {
+      method: 'POST',
+      body,
+    })
+
+    if (!response.ok) {
+      throw new Error(response.statusText)
+    }
+    return
+  },
 }
 
 export type Challenge = {

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -12,6 +12,17 @@ export const usersApi = {
       body: JSON.stringify({ oAuthToken }),
     }).then((res) => res.json() as Promise<User>)
   },
+  logout: async () => {
+    const response = await fetch('/api/logout', {
+      method: 'POST',
+      credentials: 'include',
+    })
+
+    if (!response.ok) {
+      throw new Error(response.statusText)
+    }
+    return
+  },
 }
 
 export interface UserStatus {

--- a/src/components/home-screen/UserCard.tsx
+++ b/src/components/home-screen/UserCard.tsx
@@ -3,6 +3,7 @@ import { useUserStore } from '@/store/userStore'
 import { Fragment } from 'react'
 import { useNavigate } from 'react-router-dom'
 import LogoIcon from '../common/LogoIcon'
+import { usersApi } from '@/api/users'
 
 const UserCard = () => {
   const user = useUserStore((s) => s.user)
@@ -14,10 +15,7 @@ const UserCard = () => {
   }
 
   const handleLogoutClick = () => {
-    fetch('/api/logout', {
-      method: 'POST',
-      credentials: 'include',
-    }).finally(() => {
+    usersApi.logout().finally(() => {
       logout()
     })
   }

--- a/src/pages/app/challenges/[id]/submit/individual.tsx
+++ b/src/pages/app/challenges/[id]/submit/individual.tsx
@@ -14,6 +14,7 @@ import { FormState } from '@/components/submit-screen/type'
 import ImageRow from '@/components/submit-screen/ImageRow'
 import ReviewRow from '@/components/submit-screen/ReviewRow'
 import DoneDialog from '@/components/submit-screen/DoneDialog'
+import { challengesApi } from '@/api/challenges'
 
 const ChallengeSubmitIndividual = () => {
   const f = useForm<FormState>({
@@ -42,10 +43,7 @@ const ChallengeSubmitIndividual = () => {
     formData.append('image', image)
     formData.append('review', review)
 
-    fetch(`/api/v1/challenges/${challengeId}/submit`, {
-      method: 'POST',
-      body: formData,
-    }).then(() => {
+    challengesApi.submitIndividualChallenge(challengeId, formData).then(() => {
       setOpenConfirmDialog(true)
     })
   }


### PR DESCRIPTION
이 PR은 cursor와 함께 작성되었습니다.

##  변경 사항

### 목표
- API 호출 로직을 한 곳에 모아두어 유지보수성과 테스트 용이성을 높임
- 컴포넌트, 훅 등에서 직접 fetch를 호출하는 것을 방지하여 관심사의 분리를 명확히 함
- 향후 API mock 또는 전역 에러 핸들링 전략 수립에 유리한 구조 확보

### 주요 변경사항

#### 1. API 모듈 분리
- `src/api/challenges.ts`에 `submitIndividualChallenge` 함수 추가
- `src/api/users.ts`에 `logout` 함수 추가

#### 2. 컴포넌트 수정
- `src/pages/app/challenges/[id]/submit/individual.tsx`: 직접 fetch 호출을 `challengesApi.submitIndividualChallenge`로 변경
- `src/components/home-screen/UserCard.tsx`: 직접 fetch 호출을 `usersApi.logout`으로 변경

#### 3. ESLint 규칙 추가
- `eslint.config.js`에 fetch 호출 제한 규칙 추가
- `/src/api` 디렉토리 내부에서는 fetch 호출 허용
- 다른 디렉토리에서는 fetch 호출 시 에러 발생

#### 4. 문서화
- `CONTRIBUTING.md`에 API 호출 컨벤션 가이드라인 추가
- 올바른/잘못된 사용법 예시 포함

### 검증 완료
- ✅ ESLint 검사 통과
- ✅ TypeScript 컴파일 성공
- ✅ 모든 fetch 호출이 `/src/api` 디렉토리로 이동 완료

### 관련 이슈
Closes #40

### 향후 이점
- **유지보수성 향상**: API 호출 로직이 한 곳에 집중됨
- **관심사 분리**: 컴포넌트에서 비즈니스 로직과 API 호출 로직 분리
- **테스트 용이성**: API 모듈 단위 테스트 가능
- **일관성**: 모든 API 호출이 동일한 패턴으로 처리됨
- **확장성**: API mock, 전역 에러 핸들링 등에 유리한 구조

### 사용법
이제 새로운 API 엔드포인트가 필요한 경우:
1. 해당하는 API 파일(`/src/api/challenges.ts` 또는 `/src/api/users.ts`)에 함수 추가
2. 컴포넌트에서는 API 모듈을 import하여 사용

```typescript
// ✅ 올바른 방법
import { challengesApi } from '@/api/challenges'
challengesApi.submitIndividualChallenge(challengeId, formData)
```

```typescript
// ❌ 잘못된 방법 (ESLint 에러 발생)
fetch('/api/v1/challenges/submit', { method: 'POST', body: formData })