### PR TITLE
[Feat] 정보 공유 페이지 퍼블리싱

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import ManageTeam from './pages/app/challenges/[id]/teams/[id]/joined'
 import TeamModify from './pages/app/challenges/[id]/teams/[id]/modify'
 import ChallengeSubmitTeam from './pages/app/challenges/[id]/submit/team/[teamId]'
 import { Toaster } from './components/ui/sonner'
+import InformationShare from './pages/app/InformationShare'
 
 const queryClient = new QueryClient()
 
@@ -65,6 +66,7 @@ function App() {
                 <Route path="/challenges/:challengeId/teams/:teamId" element={<TeamDetail />} />
                 <Route path="/login" element={<Login />} />
                 <Route path="/my" element={<MyPage />} />
+                <Route path="/information-share" element={<InformationShare />} />
                 <Route path="*" element={<Main />} />
               </Routes>
             )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import TeamModify from './pages/app/challenges/[id]/teams/[id]/modify'
 import ChallengeSubmitTeam from './pages/app/challenges/[id]/submit/team/[teamId]'
 import { Toaster } from './components/ui/sonner'
 import InformationShare from './pages/app/InformationShare'
+import InformationDetail from './pages/app/informations/[id]/detail'
 
 const queryClient = new QueryClient()
 
@@ -67,6 +68,7 @@ function App() {
                 <Route path="/login" element={<Login />} />
                 <Route path="/my" element={<MyPage />} />
                 <Route path="/information-share" element={<InformationShare />} />
+                <Route path="/information-share/:informationId" element={<InformationDetail />} />
                 <Route path="*" element={<Main />} />
               </Routes>
             )}

--- a/src/api/informations.ts
+++ b/src/api/informations.ts
@@ -1,0 +1,23 @@
+import { InfoCard } from '@/pages/app/InformationShare'
+import { createQueryKeys } from '@lukemorales/query-key-factory'
+
+export const informationsApi = {
+  getInformations: async () => {
+    const response = await fetch('/api/user/info')
+    const data = response.json() as Promise<InfoCard[]>
+    return data
+  },
+
+  getInformation: async (infoId: number | undefined) => {
+    const response = await fetch(`/api/user/info/${infoId}`)
+    const data = response.json() as Promise<InfoCard>
+    return data
+  },
+}
+
+const informationsKey = createQueryKeys('informations', {
+  list: () => ['list'] as const,
+  detail: (id: number | undefined) => ['detail', id] as const,
+})
+
+export const informationQueryKeys = informationsKey

--- a/src/api/informations.ts
+++ b/src/api/informations.ts
@@ -4,13 +4,13 @@ import { createQueryKeys } from '@lukemorales/query-key-factory'
 export const informationsApi = {
   getInformations: async () => {
     const response = await fetch('/api/user/info')
-    const data = response.json() as Promise<InfoCard[]>
+    const data = (await response.json()) as InfoCard[]
     return data
   },
 
   getInformation: async (infoId: number | undefined) => {
     const response = await fetch(`/api/user/info/${infoId}`)
-    const data = response.json() as Promise<InfoCard>
+    const data = (await response.json()) as InfoCard
     return data
   },
 }

--- a/src/components/Information-screen/InformationCard.tsx
+++ b/src/components/Information-screen/InformationCard.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@/lib/utils'
 import { useNavigate } from 'react-router-dom'
+import InformationLabel from './InformationLabel'
 
 type InformationCardProps = {
   id: number
@@ -40,18 +40,9 @@ const InformationCard = ({
         />
       </div>
       <div className="flex flex-col justify-baseline p-[12px]">
-        <div className="flex flex-row items-baseline justify-between gap-2 py-[10px]">
+        <div className="flex flex-row items-center justify-between gap-2 py-[10px]">
           <p className="text-md flex-1 truncate text-start font-bold">{title}</p>
-          <div
-            className={cn(
-              'flex-shrink-0 items-center justify-center rounded-[8px] px-[8px] py-[2px] text-sm',
-              categoryName === '이벤트' && 'bg-green-300 text-green-700',
-              categoryName === '커뮤니티' && 'bg-blue-300 text-blue-700',
-              categoryName === '기타' && 'bg-purple-300 text-purple-700',
-            )}
-          >
-            {categoryName}
-          </div>
+          <InformationLabel categoryName={categoryName} />
         </div>
         <p className="items-start justify-baseline text-start">{content.substring(0, 30)}</p>
       </div>

--- a/src/components/Information-screen/InformationCard.tsx
+++ b/src/components/Information-screen/InformationCard.tsx
@@ -1,0 +1,42 @@
+import { cn } from '@/lib/utils'
+
+type InformationCardProps = {
+  categoryName: string
+  title: string
+  content: string
+  thumbnailUrl: string
+}
+
+const InformationCard = ({ categoryName, title, content, thumbnailUrl }: InformationCardProps) => {
+  return (
+    <div className="m-[16px] flex min-h-[150px] flex-row items-start justify-start overflow-hidden rounded-[25px] border bg-white shadow-md">
+      <div className="h-[180px] w-[180px] flex-shrink-0">
+        <img
+          className="h-full rounded-l-[25px] bg-green-50 object-cover"
+          src={thumbnailUrl}
+          alt="활동이미지"
+          width="180"
+          height="180"
+        />
+      </div>
+      <div className="flex flex-col justify-baseline p-[12px]">
+        <div className="flex flex-row items-baseline justify-between gap-2 py-[10px]">
+          <p className="text-md flex-1 truncate text-start font-bold">{title}</p>
+          <div
+            className={cn(
+              'flex-shrink-0 items-center justify-center rounded-[8px] px-[8px] py-[2px] text-sm',
+              categoryName === '이벤트' && 'bg-green-300 text-green-700',
+              categoryName === '커뮤니티' && 'bg-blue-300 text-blue-700',
+              categoryName === '기타' && 'bg-purple-300 text-purple-700',
+            )}
+          >
+            {categoryName}
+          </div>
+        </div>
+        <p className="items-start justify-baseline text-start">{content.substring(0, 30)}</p>
+      </div>
+    </div>
+  )
+}
+
+export default InformationCard

--- a/src/components/Information-screen/InformationCard.tsx
+++ b/src/components/Information-screen/InformationCard.tsx
@@ -1,15 +1,35 @@
 import { cn } from '@/lib/utils'
+import { useNavigate } from 'react-router-dom'
 
 type InformationCardProps = {
+  id: number
   categoryName: string
   title: string
   content: string
   thumbnailUrl: string
 }
 
-const InformationCard = ({ categoryName, title, content, thumbnailUrl }: InformationCardProps) => {
+const InformationCard = ({
+  id,
+  categoryName,
+  title,
+  content,
+  thumbnailUrl,
+}: InformationCardProps) => {
+  const navigate = useNavigate()
+
+  const handleClickCard = () => {
+    const cardData = { id, categoryName, title, content, thumbnailUrl }
+    navigate(`/information-share/${id}`, {
+      state: { cardData },
+    })
+  }
+
   return (
-    <div className="m-[16px] flex min-h-[150px] flex-row items-start justify-start overflow-hidden rounded-[25px] border bg-white shadow-md">
+    <div
+      className="m-[16px] flex min-h-[150px] cursor-pointer flex-row items-start justify-start overflow-hidden rounded-[25px] border bg-white shadow-md"
+      onClick={handleClickCard}
+    >
       <div className="h-[180px] w-[180px] flex-shrink-0">
         <img
           className="h-full rounded-l-[25px] bg-green-50 object-cover"

--- a/src/components/Information-screen/InformationLabel.tsx
+++ b/src/components/Information-screen/InformationLabel.tsx
@@ -1,0 +1,22 @@
+import { cn } from '@/lib/utils'
+
+type InformationLabelProps = {
+  categoryName: string
+}
+
+const InformationLabel = ({ categoryName }: InformationLabelProps) => {
+  return (
+    <div
+      className={cn(
+        'flex-shrink-0 items-center justify-center rounded-[8px] px-[8px] py-[4px] text-sm',
+        categoryName === '이벤트' && 'bg-green-100 text-green-700',
+        categoryName === '커뮤니티' && 'bg-blue-100 text-blue-700',
+        categoryName === '기타' && 'bg-purple-100 text-purple-700',
+      )}
+    >
+      {categoryName}
+    </div>
+  )
+}
+
+export default InformationLabel

--- a/src/components/Information-screen/InformationTab.tsx
+++ b/src/components/Information-screen/InformationTab.tsx
@@ -1,0 +1,30 @@
+export type TabType = '전체' | '참여형' | '커뮤니티'
+
+interface InformationTabProps {
+  onTabChange: (tabType: TabType) => void
+  activeTab?: TabType
+}
+
+const InformationTab = ({ onTabChange, activeTab }: InformationTabProps) => {
+  const tabs: TabType[] = ['전체', '참여형', '커뮤니티']
+
+  const handleTabClick = (tabType: TabType) => {
+    onTabChange(tabType)
+  }
+
+  return (
+    <div className="text-md flex flex-row items-center justify-center gap-[80px] bg-white px-[20px] text-center">
+      {tabs.map((tab) => (
+        <div
+          key={tab}
+          className={`flex-1 cursor-pointer p-[10px] py-[16px] text-center transition-colors hover:font-bold ${activeTab === tab ? 'font-bold text-green-600' : ''} `}
+          onClick={() => handleTabClick(tab)}
+        >
+          {tab}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default InformationTab

--- a/src/components/common/BottomNav.tsx
+++ b/src/components/common/BottomNav.tsx
@@ -38,6 +38,9 @@ function BottomNavigation() {
         case 0:
           navigate('/')
           break
+        case 1:
+          navigate('/information-share')
+          break
         default:
           break
       }

--- a/src/hooks/useInformation.ts
+++ b/src/hooks/useInformation.ts
@@ -1,0 +1,9 @@
+import { informationQueryKeys, informationsApi } from '@/api/informations'
+import { useQuery } from '@tanstack/react-query'
+
+export const useInformation = (id: number | undefined) => {
+  return useQuery({
+    queryKey: informationQueryKeys.detail(id).queryKey,
+    queryFn: () => informationsApi.getInformation(id),
+  })
+}

--- a/src/hooks/useInformations.ts
+++ b/src/hooks/useInformations.ts
@@ -1,0 +1,9 @@
+import { informationQueryKeys, informationsApi } from '@/api/informations'
+import { useQuery } from '@tanstack/react-query'
+
+export const useInformations = () => {
+  return useQuery({
+    queryKey: informationQueryKeys.list().queryKey,
+    queryFn: informationsApi.getInformations,
+  })
+}

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,5 +1,6 @@
 // https://mswjs.io/docs/integrations/browser
 import { setupWorker } from 'msw/browser'
 import { handlers } from './handlers'
+import { InformationHandlers } from './informationHandlers'
 
-export const worker = setupWorker(...handlers)
+export const worker = setupWorker(...handlers, ...InformationHandlers)

--- a/src/mocks/informationHandlers.ts
+++ b/src/mocks/informationHandlers.ts
@@ -1,0 +1,21 @@
+import { InformationMockingStore } from '@/store/InformationMockingStore'
+import { http, HttpResponse } from 'msw'
+
+export const InformationHandlers = [
+  http.get('/api/user/info', () => {
+    const response = InformationMockingStore.getState().getInformations()
+    return HttpResponse.json(response)
+  }),
+
+  http.get('/api/user/info/:infoId', ({ params }) => {
+    const infoId = parseInt(params['infoId'] as string)
+
+    const response = InformationMockingStore.getState().getInformationById(infoId)
+
+    if (response === undefined) {
+      return HttpResponse.json(response, { status: 404 })
+    }
+
+    return HttpResponse.json(response)
+  }),
+]

--- a/src/pages/app/InformationShare.tsx
+++ b/src/pages/app/InformationShare.tsx
@@ -3,7 +3,7 @@ import InformationCard from '@/components/Information-screen/InformationCard'
 import InformationTab, { TabType } from '@/components/Information-screen/InformationTab'
 import { useEffect, useState } from 'react'
 
-type InfoCard = {
+export type InfoCard = {
   id: number
   infoCategoryName: string
   title: string

--- a/src/pages/app/InformationShare.tsx
+++ b/src/pages/app/InformationShare.tsx
@@ -50,7 +50,6 @@ function InformationShare() {
         <hr />
         <InformationTab onTabChange={handleTabChange} activeTab={activeTab} />
       </header>
-
       <div className="overflow-y-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         {filteredData.map((item) => (
           <InformationCard
@@ -63,7 +62,6 @@ function InformationShare() {
           />
         ))}
       </div>
-
       <footer>
         <BottomNavigation />
       </footer>

--- a/src/pages/app/InformationShare.tsx
+++ b/src/pages/app/InformationShare.tsx
@@ -1,6 +1,7 @@
 import BottomNavigation from '@/components/common/BottomNav'
 import InformationCard from '@/components/Information-screen/InformationCard'
 import InformationTab, { TabType } from '@/components/Information-screen/InformationTab'
+import { useInformations } from '@/hooks/useInformations'
 import { useEffect, useState } from 'react'
 
 export type InfoCard = {
@@ -11,53 +12,9 @@ export type InfoCard = {
   content: string
 }
 
-const infoCardData: InfoCard[] = [
-  {
-    id: 1,
-    infoCategoryName: '이벤트',
-    title: '친환경적인 일상 실천하기',
-    thumbnailUrl: '/img/2.png',
-    content: '친환경 실천 방법에 대한 내용입니다.',
-  },
-  {
-    id: 2,
-    infoCategoryName: '이벤트',
-    title: '제로웨이스트 워크숍',
-    thumbnailUrl: '/img/2.png',
-    content:
-      '일상에서 쓰레기를 줄이는 방법을 배우는 워크숍입니다. 친환경 생필용품을 직접 만들어보고, 제로웨이스트 라이프 스타일을 함께 해봐요.',
-  },
-  {
-    id: 3,
-    infoCategoryName: '커뮤니티',
-    title: '친환경 제품 만들기',
-    thumbnailUrl: '/img/2.png',
-    content: '버려지는 물건으로 새로운 가치를 만드는 업사이클링 DIY 클래스입니다.',
-  },
-  {
-    id: 4,
-    infoCategoryName: '커뮤니티',
-    title: '제로 피크닉',
-    thumbnailUrl: '/img/2.png',
-    content: '일회용품 없이 즐기는 친환경 피크닉 모임입니다.',
-  },
-  {
-    id: 5,
-    infoCategoryName: '기타',
-    title: '친환경 마켓',
-    thumbnailUrl: '/img/2.png',
-    content: '지속가능한 생활을 위한 친환경 제품들을 만나볼 수 있는 마켓입니다.',
-  },
-  {
-    id: 6,
-    infoCategoryName: '이벤트',
-    title: '업사이클링 워크숍',
-    thumbnailUrl: '/img/2.png',
-    content: '버려지는 물건에 새 생명을 불어넣는 업사이클링 워크숍입니다.',
-  },
-]
-
 function InformationShare() {
+  const { isLoading, data: infoData } = useInformations()
+
   const [activeTab, setActiveTab] = useState<TabType>('전체')
   const [filteredData, setFilteredData] = useState<InfoCard[]>([])
 
@@ -65,7 +22,9 @@ function InformationShare() {
     setActiveTab(tabType)
   }
 
-  const filterData = (data: InfoCard[], tabType: TabType) => {
+  const filterData = (data: InfoCard[] | undefined, tabType: TabType) => {
+    if (!data) return []
+
     switch (tabType) {
       case '전체':
         return data
@@ -77,8 +36,10 @@ function InformationShare() {
   }
 
   useEffect(() => {
-    setFilteredData(filterData(infoCardData, activeTab))
-  }, [activeTab])
+    setFilteredData(filterData(infoData, activeTab))
+  }, [activeTab, infoData])
+
+  if (isLoading) return <div>로딩 중....</div>
 
   return (
     <div className="grid h-screen w-full grid-rows-[auto_1fr_auto]">

--- a/src/pages/app/InformationShare.tsx
+++ b/src/pages/app/InformationShare.tsx
@@ -94,6 +94,7 @@ function InformationShare() {
         {filteredData.map((item) => (
           <InformationCard
             key={item.id}
+            id={item.id}
             categoryName={item.infoCategoryName}
             title={item.title}
             content={item.content}

--- a/src/pages/app/InformationShare.tsx
+++ b/src/pages/app/InformationShare.tsx
@@ -1,0 +1,5 @@
+function InformationShare() {
+  return <div>gdgd</div>
+}
+
+export default InformationShare

--- a/src/pages/app/InformationShare.tsx
+++ b/src/pages/app/InformationShare.tsx
@@ -1,5 +1,112 @@
+import BottomNavigation from '@/components/common/BottomNav'
+import InformationCard from '@/components/Information-screen/InformationCard'
+import InformationTab, { TabType } from '@/components/Information-screen/InformationTab'
+import { useEffect, useState } from 'react'
+
+type InfoCard = {
+  id: number
+  infoCategoryName: string
+  title: string
+  thumbnailUrl: string
+  content: string
+}
+
+const infoCardData: InfoCard[] = [
+  {
+    id: 1,
+    infoCategoryName: '이벤트',
+    title: '친환경적인 일상 실천하기',
+    thumbnailUrl: '/img/2.png',
+    content: '친환경 실천 방법에 대한 내용입니다.',
+  },
+  {
+    id: 2,
+    infoCategoryName: '이벤트',
+    title: '제로웨이스트 워크숍',
+    thumbnailUrl: '/img/2.png',
+    content:
+      '일상에서 쓰레기를 줄이는 방법을 배우는 워크숍입니다. 친환경 생필용품을 직접 만들어보고, 제로웨이스트 라이프 스타일을 함께 해봐요.',
+  },
+  {
+    id: 3,
+    infoCategoryName: '커뮤니티',
+    title: '친환경 제품 만들기',
+    thumbnailUrl: '/img/2.png',
+    content: '버려지는 물건으로 새로운 가치를 만드는 업사이클링 DIY 클래스입니다.',
+  },
+  {
+    id: 4,
+    infoCategoryName: '커뮤니티',
+    title: '제로 피크닉',
+    thumbnailUrl: '/img/2.png',
+    content: '일회용품 없이 즐기는 친환경 피크닉 모임입니다.',
+  },
+  {
+    id: 5,
+    infoCategoryName: '기타',
+    title: '친환경 마켓',
+    thumbnailUrl: '/img/2.png',
+    content: '지속가능한 생활을 위한 친환경 제품들을 만나볼 수 있는 마켓입니다.',
+  },
+  {
+    id: 6,
+    infoCategoryName: '이벤트',
+    title: '업사이클링 워크숍',
+    thumbnailUrl: '/img/2.png',
+    content: '버려지는 물건에 새 생명을 불어넣는 업사이클링 워크숍입니다.',
+  },
+]
+
 function InformationShare() {
-  return <div>gdgd</div>
+  const [activeTab, setActiveTab] = useState<TabType>('전체')
+  const [filteredData, setFilteredData] = useState<InfoCard[]>([])
+
+  const handleTabChange = (tabType: TabType) => {
+    setActiveTab(tabType)
+  }
+
+  const filterData = (data: InfoCard[], tabType: TabType) => {
+    switch (tabType) {
+      case '전체':
+        return data
+      case '참여형':
+        return data.filter((item) => item.infoCategoryName === '이벤트')
+      case '커뮤니티':
+        return data.filter((item) => item.infoCategoryName === '커뮤니티')
+    }
+  }
+
+  useEffect(() => {
+    setFilteredData(filterData(infoCardData, activeTab))
+  }, [activeTab])
+
+  return (
+    <div className="grid h-screen w-full grid-rows-[auto_1fr_auto]">
+      <header>
+        <div className="items-center justify-center bg-white p-[22px] text-xl font-bold">
+          정보공유
+        </div>
+        <hr />
+        <InformationTab onTabChange={handleTabChange} activeTab={activeTab} />
+      </header>
+
+      <div className="overflow-y-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        {filteredData.map((item) => (
+          <InformationCard
+            key={item.id}
+            categoryName={item.infoCategoryName}
+            title={item.title}
+            content={item.content}
+            thumbnailUrl={item.thumbnailUrl}
+          />
+        ))}
+      </div>
+
+      <footer>
+        <BottomNavigation />
+      </footer>
+    </div>
+  )
 }
 
 export default InformationShare

--- a/src/pages/app/informations/[id]/detail.tsx
+++ b/src/pages/app/informations/[id]/detail.tsx
@@ -1,0 +1,20 @@
+import { useLocation } from 'react-router-dom'
+
+const InformationDetail = () => {
+  const location = useLocation()
+  const { cardData } = location.state || {}
+
+  if (!cardData) {
+    return <div>데이터를 찾을 수 없습니다.</div>
+  }
+
+  return (
+    <div>
+      <h1>{cardData.title}</h1>
+      <p>{cardData.content}</p>
+      {/* 상세 내용 */}
+    </div>
+  )
+}
+
+export default InformationDetail

--- a/src/pages/app/informations/[id]/detail.tsx
+++ b/src/pages/app/informations/[id]/detail.tsx
@@ -1,18 +1,37 @@
-import { useLocation } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { ChevronLeft } from 'lucide-react'
+import InformationLabel from '@/components/Information-screen/InformationLabel'
 
 const InformationDetail = () => {
   const location = useLocation()
+  const navigate = useNavigate()
   const { cardData } = location.state || {}
 
   if (!cardData) {
     return <div>데이터를 찾을 수 없습니다.</div>
   }
 
+  const handleBackButtonClick = () => {
+    navigate(-1)
+  }
+
   return (
-    <div>
-      <h1>{cardData.title}</h1>
-      <p>{cardData.content}</p>
-      {/* 상세 내용 */}
+    <div className="flex w-full flex-col bg-white">
+      <header className="flex w-full flex-row justify-baseline gap-[140px] bg-white p-[16px] text-xl">
+        <ChevronLeft size={24} className="cursor-pointer" onClick={handleBackButtonClick} />
+        <p className="text-center font-bold text-black">활동 상세</p>
+      </header>
+      <div className="bg-green-50">
+        <img src={cardData.thumbnailUrl} className="w-full" />
+      </div>
+      <div className="flex flex-row items-center justify-between p-[16px]">
+        <div className="text-xl font-bold">{cardData.title}</div>
+        <InformationLabel categoryName={cardData.categoryName} />
+      </div>
+      <div className="flex flex-col text-start">
+        <p className="border-b-2 px-[16px] pt-[16px] text-xl font-bold text-black">소개</p>
+        <p className="p-[16px] text-gray-500">{cardData.content}</p>
+      </div>
     </div>
   )
 }

--- a/src/pages/app/informations/[id]/detail.tsx
+++ b/src/pages/app/informations/[id]/detail.tsx
@@ -1,11 +1,15 @@
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { ChevronLeft } from 'lucide-react'
 import InformationLabel from '@/components/Information-screen/InformationLabel'
+import { useInformation } from '@/hooks/useInformation'
 
 const InformationDetail = () => {
-  const location = useLocation()
   const navigate = useNavigate()
-  const { cardData } = location.state || {}
+  const { informationId } = useParams<{ informationId: string }>()
+  const numericId = informationId ? parseInt(informationId) : undefined
+  const { isLoading, data: cardData } = useInformation(numericId)
+
+  if (isLoading) return <div>로딩 중...</div>
 
   if (!cardData) {
     return <div>데이터를 찾을 수 없습니다.</div>
@@ -26,7 +30,7 @@ const InformationDetail = () => {
       </div>
       <div className="flex flex-row items-center justify-between p-[16px]">
         <div className="text-xl font-bold">{cardData.title}</div>
-        <InformationLabel categoryName={cardData.categoryName} />
+        <InformationLabel categoryName={cardData.infoCategoryName} />
       </div>
       <div className="flex flex-col text-start">
         <p className="border-b-2 px-[16px] pt-[16px] text-xl font-bold text-black">소개</p>

--- a/src/store/InformationMockingStore.ts
+++ b/src/store/InformationMockingStore.ts
@@ -1,0 +1,72 @@
+import { InfoCard } from '@/pages/app/InformationShare'
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+
+interface InformationMockingStore {
+  informations: InfoCard[]
+  getInformations: () => InfoCard[]
+  getInformationById: (id: number) => InfoCard | undefined
+}
+
+const infoCardData: InfoCard[] = [
+  {
+    id: 1,
+    infoCategoryName: '이벤트',
+    title: '친환경적인 일상 실천하기',
+    thumbnailUrl: '/img/2.png',
+    content: '친환경 실천 방법에 대한 내용입니다.',
+  },
+  {
+    id: 2,
+    infoCategoryName: '이벤트',
+    title: '제로웨이스트 워크숍',
+    thumbnailUrl: '/img/2.png',
+    content:
+      '일상에서 쓰레기를 줄이는 방법을 배우는 워크숍입니다. 친환경 생필용품을 직접 만들어보고, 제로웨이스트 라이프 스타일을 함께 해봐요.',
+  },
+  {
+    id: 3,
+    infoCategoryName: '커뮤니티',
+    title: '친환경 제품 만들기',
+    thumbnailUrl: '/img/2.png',
+    content: '버려지는 물건으로 새로운 가치를 만드는 업사이클링 DIY 클래스입니다.',
+  },
+  {
+    id: 4,
+    infoCategoryName: '커뮤니티',
+    title: '제로 피크닉',
+    thumbnailUrl: '/img/2.png',
+    content: '일회용품 없이 즐기는 친환경 피크닉 모임입니다.',
+  },
+  {
+    id: 5,
+    infoCategoryName: '기타',
+    title: '친환경 마켓',
+    thumbnailUrl: '/img/2.png',
+    content: '지속가능한 생활을 위한 친환경 제품들을 만나볼 수 있는 마켓입니다.',
+  },
+  {
+    id: 6,
+    infoCategoryName: '이벤트',
+    title: '업사이클링 워크숍',
+    thumbnailUrl: '/img/2.png',
+    content: '버려지는 물건에 새 생명을 불어넣는 업사이클링 워크숍입니다.',
+  },
+]
+
+export const InformationMockingStore = create<InformationMockingStore>()(
+  devtools(
+    (set, get) => ({
+      informations: infoCardData,
+
+      getInformations: () => get().informations,
+
+      getInformationById: (id: number) => get().informations.filter((info) => info.id === id),
+
+      setInformations: (informations: InfoCard[]) => set({ informations }),
+    }),
+    {
+      name: 'information-store',
+    },
+  ),
+)

--- a/src/store/InformationMockingStore.ts
+++ b/src/store/InformationMockingStore.ts
@@ -61,7 +61,7 @@ export const InformationMockingStore = create<InformationMockingStore>()(
 
       getInformations: () => get().informations,
 
-      getInformationById: (id: number) => get().informations.filter((info) => info.id === id),
+      getInformationById: (id: number) => get().informations.find((info) => info.id === id),
 
       setInformations: (informations: InfoCard[]) => set({ informations }),
     }),


### PR DESCRIPTION
## 🔗 관련 이슈 : (#22)

## 📌 개요
- 정보 공유 페이지 / 정보 공유 상세 페이지 퍼블리싱 완료

## 🔍 작업 유형
- [x] 정보 공유 페이지 컴포넌트 구현(feat)
- [x] 정보 공유 상세 페이지 구현(feat)
- [x] 정보 공유 관련 목 데이터 및 핸들러 구현(feat)
- [x] zustand를 이용한 information Store 생성(feat)
- [x] 리액트 쿼리를 이용하여 데이터 불러오는 훅 메서드 구현(feat)

## 🧩 작업 상세
- 스크롤을 가리는 것을 굳이 패키지를 설치 안하고 classname에 추가하였는데 이전 포인트 상점에서는 scrollbar-hide라는 옵션을 만들어서 작성했던 걸로 기억합니다. 그런데도 패키지 설치를 이중적으로 하였는데 이와 관련해서는 삭제할 예정이며 개인적으로 css 에서 util css로 만들어 포인트 상점에서 사용했던 방법이 좋았던 것 같습니다.
```js
<div className="overflow-y-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
```
- 각 페이지 마다 분기 처리를 추가하였습니다. 이 부분도 분기 처리외에는 제가 떠오르는 부분이 없어서 명확하게 해결을 못했던 것 같습니다. 데이터를 비동기 적으로 async/await 을 이용하여 불러왔는데도 undeinfed 된 데이터가 먼저 렌더링 되었는데 이는 리액트 쿼리의 특성이라고 답변을 들어 분기처리를 해야겠다고 생각하였습니다.
```js
if (isLoading) return <div>로딩 중....</div>
```

## 🖼️ 화면 스크린샷 (Optional)
<img width="150" height="200" alt="image" src="https://github.com/user-attachments/assets/2a135c1d-c2f4-4203-a8c2-a29cf323a9be" />
<img width="150" height="200" alt="image" src="https://github.com/user-attachments/assets/4642b5a3-d7d0-4145-ad38-e795dc94c6b6" />


## 💬 리뷰 요구사항 (Optional)
리액트 쿼리를 이용하여 데이터를 불러오는 훅 메서드를 사용할 때 isLoading을 통해 분기를 추가하였는데 이 경우를 고려해야 될 지 애매했던 것 같습니다.
