### PR TITLE
[Fix] make InputImage clickable by forwarding ref and removing control…

### DIFF
--- a/src/components/common/form/input-image.tsx
+++ b/src/components/common/form/input-image.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps } from 'react'
+import React, { ComponentProps, forwardRef } from 'react'
 import { imagesApi } from '@/api/images'
 import { toast } from 'sonner'
 import { omit } from 'es-toolkit'
@@ -12,12 +12,10 @@ interface InputProfileImageProps
   purpose: Parameters<typeof imagesApi.uploadImage>[0]
 }
 
-function InputImage({
-  onChange: onChange,
-  onChangePreview,
-  purpose,
-  ...restProps
-}: InputProfileImageProps) {
+function InputImageImpl(
+  { onChange: onChange, onChangePreview, purpose, ...restProps }: InputProfileImageProps,
+  ref: React.Ref<HTMLInputElement>,
+) {
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (file) {
@@ -30,7 +28,6 @@ function InputImage({
           return
         }
         onChange(res.result)
-        // 선택 후 다시 같은 파일 선택 가능하게 초기화하려면:
         if (e.target) e.target.value = ''
       })
     }
@@ -38,6 +35,7 @@ function InputImage({
 
   return (
     <input
+      ref={ref}
       type="file"
       accept="image/*"
       onChange={handleFileChange}
@@ -46,6 +44,8 @@ function InputImage({
     />
   )
 }
+
+const InputImage = forwardRef<HTMLInputElement, InputProfileImageProps>(InputImageImpl)
 
 InputImage.displayName = 'InputImage'
 export default InputImage

--- a/src/components/common/form/input-image.tsx
+++ b/src/components/common/form/input-image.tsx
@@ -30,6 +30,8 @@ function InputImage({
           return
         }
         onChange(res.result)
+        // 선택 후 다시 같은 파일 선택 가능하게 초기화하려면:
+        if (e.target) e.target.value = ''
       })
     }
   }
@@ -40,10 +42,10 @@ function InputImage({
       accept="image/*"
       onChange={handleFileChange}
       {...omit(restProps, ['localFileName'])}
-      value={restProps.localFileName ?? undefined}
       className={cn(restProps.className, 'cursor-pointer')}
     />
   )
 }
 
+InputImage.displayName = 'InputImage'
 export default InputImage

--- a/src/components/common/input-profile-image.tsx
+++ b/src/components/common/input-profile-image.tsx
@@ -43,6 +43,7 @@ function InputProfileImage({
         className="absolute right-0 bottom-0"
       />
       <InputImage
+        ref={fileInputRef}
         purpose="profile"
         localFileName={source}
         onChange={onChange}


### PR DESCRIPTION
## 🔗 관련 이슈 :  #116 

## 📌 개요
https://www.notion.so/249adf41302d80f08035c0f7eba6c043?source=copy_link
InputImage 컴포넌트가 클릭해도 file input이 뜨지 않는 버그 해결 건입니다.

## 🔍 작업 유형
- [ ] 기능 추가 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 스타일 변경 (style)
- [ ] 설정 변경 (chore)
- [ ] 테스트 코드 추가 또는 수정 (test)
- [ ] CI/CD (ci)

## 🧩 작업 상세
원인을 찾아보니 ref가 연결이 안되어서 이를 forwardRef로 연결해주었고, 
file input은 value를 직접 제어하는 제어 컴포넌트로 만들면 안된다고 하여 value 속성을 뺴주었습니다.
