### PR TITLE
[Fix] strengthen nickname check condition to include availability flag

### DIFF
--- a/src/components/edit-profile-screen/nickname-checkt-input/input-nickname.tsx
+++ b/src/components/edit-profile-screen/nickname-checkt-input/input-nickname.tsx
@@ -32,7 +32,7 @@ const InputNickname = forwardRef<HTMLInputElement, InputNicknameProps>(
 
       const res = await usersApi.checkNicknameDuplicate(nickname)
 
-      if ('nickname' in res) {
+      if ('nickname' in res && res.available) {
         setIsNicknameDuplicated(true)
         toast.success('사용 가능한 닉네임입니다.')
       } else {


### PR DESCRIPTION
## 🔗 관련 이슈 :  #118 

## 📌 개요
중복되는 닉네임 중복검사 안되는 문제 해결 건입니다.
notion :https://www.notion.so/249adf41302d809bb24ddd0804ebc742?source=copy_link

## 🔍 작업 유형
- [ ] 기능 추가 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 스타일 변경 (style)
- [ ] 설정 변경 (chore)
- [ ] 테스트 코드 추가 또는 수정 (test)
- [ ] CI/CD (ci)

## 🧩 작업 상세
중복된 닉네임으로 요청 시 400 Bad Request가 뜰 줄 알았으나 사실은 아래와 같이 오고 있었고,
```
{
  "nickname": "지환",
  "available": false,
  "message": "중복된 닉네임이 존재합니다."
}
```
하여 에러 핸들링 부분에 if절을 더 강화했습니다.
보다 근본적인 해결책으로 200이 아닌 400이 오도록 하는 작업은 백엔드에 요청드린 상황입니다.
https://discord.com/channels/1364946712967381052/1374691697971171460/1403629662575525938

## 🖼️ 화면 스크린샷 (Optional)
https://github.com/user-attachments/assets/e1e2b6a0-b5ed-4d81-a030-9648e1cab447