### PR TITLE
[Fix] update function named updateNickname in EditProfileForm

### DIFF
--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -121,8 +121,8 @@ type GetMyPointsHistoryResponse = BaseApiResponse<{
 type PostWithdrawResponse = BaseApiResponse<undefined>
 
 type PutUserProfileResponse = BaseApiResponse<{
-  nickname: 'string'
-  profileImageUrl: 'string'
+  nickname: string
+  profileImageUrl: string
 }>
 
 type CheckNicknameDuplicateReponse =

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -120,7 +120,10 @@ type GetMyPointsHistoryResponse = BaseApiResponse<{
 
 type PostWithdrawResponse = BaseApiResponse<undefined>
 
-type PutUserProfileResponse = { nickname: string; profileImageUrl: string } | { message: string }
+type PutUserProfileResponse = BaseApiResponse<{
+  nickname: 'string'
+  profileImageUrl: 'string'
+}>
 
 type CheckNicknameDuplicateReponse =
   | {

--- a/src/components/edit-profile-screen/edit-profile-form.tsx
+++ b/src/components/edit-profile-screen/edit-profile-form.tsx
@@ -1,10 +1,11 @@
-import { usersApi } from '@/api/users'
+import { usersApi, usersQueryKeys } from '@/api/users'
 import InputProfileImage from '@/components/common/input-profile-image'
 import ConfirmDialog from '@/components/common/modal/confirm-dialog'
 import CurrentNickname from '@/components/edit-profile-screen/nickname-checkt-input/current-nickname'
 import InputNickname from '@/components/edit-profile-screen/nickname-checkt-input/input-nickname'
 import SubmitEditButton from '@/components/edit-profile-screen/submit-edit-button'
 import useUserName from '@/hooks/use-user-name'
+import { useQueryClient } from '@tanstack/react-query'
 import { Fragment, useState } from 'react'
 import { Controller, SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
@@ -20,6 +21,7 @@ function EditProfileForm() {
   const [showConfirmModal, setShowConfirmModal] = useState(false)
   // @TODO 현재 nickname을 조회하거나 같이 주는 api가 없는 것 같음(백엔드에 문의 예정). 현재는 name으로 쓰고 있으나, 만약 추가된다면 nickname으로 바뀔 예정
   const userNickname = useUserName()
+  const qc = useQueryClient()
 
   const { control, handleSubmit } = useForm<FormState>({
     defaultValues: {
@@ -49,7 +51,10 @@ function EditProfileForm() {
     const res = await usersApi.putUserProfile(pendingData.nickname, pendingData.profileImage ?? '')
     if (res.success) {
       setShowConfirmModal(false)
-      window.location.reload()
+      await qc.invalidateQueries({
+        queryKey: usersQueryKeys['users/me']['member'].queryKey,
+        refetchType: 'active',
+      })
     }
   }
 

--- a/src/components/edit-profile-screen/edit-profile-form.tsx
+++ b/src/components/edit-profile-screen/edit-profile-form.tsx
@@ -44,9 +44,13 @@ function EditProfileForm() {
   }
 
   const updateNickname = async () => {
-    if (!pendingData?.nickname || !pendingData.profileImage) return
+    if (!pendingData?.nickname) return
 
-    await usersApi.putUserProfile(pendingData.nickname, pendingData.profileImage)
+    const res = await usersApi.putUserProfile(pendingData.nickname, pendingData.profileImage ?? '')
+    if (res.success) {
+      setShowConfirmModal(false)
+      window.location.reload()
+    }
   }
 
   return (


### PR DESCRIPTION
## 🔗 관련 이슈 : #120 

## 📌 개요
edit-profile 페이지에서 닉네임 수정 확인 눌러도 동작하지 않는 문제 개선 건입니다.

## 🔍 작업 유형
- [ ] 기능 추가 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 스타일 변경 (style)
- [ ] 설정 변경 (chore)
- [ ] 테스트 코드 추가 또는 수정 (test)
- [ ] CI/CD (ci)

## 🧩 작업 상세
1. response type이 swagger 명세와 조금 달라 수정했습니다.
2. res.success일 때 모달을 사라지게 하고, realod를 시켜 업데이트된 닉네임이 보이도록 했습니다.
