### PR TITLE
[Fix] post QA problem solved

### DIFF
--- a/src/components/post-screen/post-item.tsx
+++ b/src/components/post-screen/post-item.tsx
@@ -21,10 +21,10 @@ const PostItem = ({ id, categoryName, title, content, thumbnailUrl }: PostItemPr
 
   return (
     <div
-      className="scrollbar-hide m-4 flex max-h-full max-w-full cursor-pointer flex-row items-start justify-start overflow-y-auto rounded-[25px] border bg-white shadow-md"
+      className="scrollbar-hide m-4 flex max-w-full cursor-pointer flex-row items-start justify-start overflow-y-auto rounded-[25px] border bg-white shadow-md"
       onClick={handleClickCard}
     >
-      <div className="h-32 w-32 flex-shrink-0 sm:h-40 sm:w-40">
+      <div className="h-36 w-36 flex-shrink-0 sm:h-42 sm:w-42">
         <img
           className="h-full w-full rounded-l-[25px] bg-green-50 object-cover"
           src={thumbnailUrl}
@@ -33,12 +33,14 @@ const PostItem = ({ id, categoryName, title, content, thumbnailUrl }: PostItemPr
           height="180"
         />
       </div>
-      <div className="flex flex-1 flex-col justify-baseline p-2">
+      <div className="flex flex-1 flex-col justify-baseline px-2 py-1">
         <div className="flex flex-row items-center justify-between py-2">
           <p className="text-md flex flex-1 text-start font-bold">{title}</p>
           <CategoryLabel categoryName={categoryName} />
         </div>
-        <p className="items-start justify-baseline text-start">{content.substring(0, 30)}</p>
+        <p className="items-start justify-baseline text-start">
+          {content.length > 30 ? `${content.substring(0, 30)}...` : content}
+        </p>
       </div>
     </div>
   )


### PR DESCRIPTION
## 🔗 관련 이슈 : #125 

## 📌 개요

QA 과정 중 생긴 정보 공유 페이지의 문제점들을 개선하였습니다.

## 🔍 작업 유형

- [ ] 기능 추가 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [x] 스타일 변경 (style)
- [ ] 설정 변경 (chore)
- [ ] 테스트 코드 추가 또는 수정 (test)
- [ ] CI/CD (ci)

## 🧩 작업 상세

기존 스타일링이 픽셀 단위로 적용되어 tailwindcss -<number> 로 변경하여 반응형으로 패딩과 마진을 수정하였습니다
기존 정보 공유 카테고리에서 몇 몇 변경 사항이 있어 변경사항을 적용하였습니다.
컴포넌트 배치를 수정하였습니다

## 🖼️ 화면 스크린샷 (Optional)

<img width="200" height="400" alt="image" src="https://github.com/user-attachments/assets/b0793f16-7822-47ba-b1c1-2f139ee06271" />


## 💬 리뷰 요구사항 (Optional)
현재 정보 공유 소개 부분에서 공백이 제거 되어 줄 바꿈을 하고 글 작성을 해도 공백이 제거되어 나오는 문제를 해결하지 못하는 상황입니다. 이 문제와 같은 getPost api 함수와 posts/[id] 내부 컴포넌트에도 공백 처리는 되어 있지 않아 제 선에선 문제점이 없는 걸로 보입니다. 
결론적으로, 저는 이 문제를 해결하기 위해서는 백엔드에서의 처리에 문제가 있다고 생각하는데 그 전에 혹시 제 코드에서 문제되는 부분이 있는지 확인 요청 부탁드리려고 합니다

