### PR TITLE
fix: change default ui in InputNickname and SubmitButton

### DIFF
--- a/src/components/edit-profile-screen/edit-profile-form.tsx
+++ b/src/components/edit-profile-screen/edit-profile-form.tsx
@@ -105,7 +105,7 @@ function EditProfileForm() {
         </fieldset>
         <fieldset className="mt-auto flex w-full">
           <legend className="sr-only">제출</legend>
-          <SubmitEditButton />
+          <SubmitEditButton isNicknameDuplicated={isNicknameDuplicated} />
         </fieldset>
       </form>
       {showConfirmModal && (

--- a/src/components/edit-profile-screen/edit-profile-form.tsx
+++ b/src/components/edit-profile-screen/edit-profile-form.tsx
@@ -92,6 +92,7 @@ function EditProfileForm() {
               name="nickname"
               render={({ field }) => (
                 <InputNickname
+                  mode="edit"
                   value={field.value ?? ''}
                   onChange={(e) => {
                     field.onChange(e)

--- a/src/components/edit-profile-screen/nickname-checkt-input/input-nickname.tsx
+++ b/src/components/edit-profile-screen/nickname-checkt-input/input-nickname.tsx
@@ -59,7 +59,7 @@ const InputNickname = forwardRef<HTMLInputElement, InputNicknameProps>(
           <button
             type="button"
             onClick={handleClick}
-            className="hover:bg-mountain_meadow rounded-r-md bg-gray-300 px-8 text-sm text-white"
+            className="hover:bg-mountain_meadow/80 bg-mountain_meadow rounded-r-md px-8 text-sm text-white"
           >
             중복 확인
           </button>

--- a/src/components/edit-profile-screen/nickname-checkt-input/input-nickname.tsx
+++ b/src/components/edit-profile-screen/nickname-checkt-input/input-nickname.tsx
@@ -52,7 +52,7 @@ const InputNickname = forwardRef<HTMLInputElement, InputNicknameProps>(
             ref={ref}
             id={id}
             type="text"
-            placeholder={mode === 'new' ? '새 닉네임을 입력해주세요.' : '닉네임 입력'}
+            placeholder={mode === 'edit' ? '새 닉네임을 입력해주세요.' : '닉네임을 입력해주세요.'}
             className="flex-1 px-3 py-4 text-sm focus:outline-none"
             {...props}
           />

--- a/src/components/edit-profile-screen/nickname-checkt-input/input-nickname.tsx
+++ b/src/components/edit-profile-screen/nickname-checkt-input/input-nickname.tsx
@@ -52,7 +52,7 @@ const InputNickname = forwardRef<HTMLInputElement, InputNicknameProps>(
             ref={ref}
             id={id}
             type="text"
-            placeholder={mode === 'edit' ? '새 닉네임을 입력해주세요.' : '닉네임을 입력해주세요.'}
+            placeholder="새 닉네임을 입력해주세요."
             className="flex-1 px-3 py-4 text-sm focus:outline-none"
             {...props}
           />

--- a/src/components/edit-profile-screen/submit-edit-button.tsx
+++ b/src/components/edit-profile-screen/submit-edit-button.tsx
@@ -1,8 +1,8 @@
 import { Button } from '@/components/ui/button'
 
-function SubmitEditButton() {
+function SubmitEditButton({ isNicknameDuplicated }: { isNicknameDuplicated: boolean }) {
   return (
-    <Button size="flex" type="submit">
+    <Button size="flex" type="submit" variant={isNicknameDuplicated ? 'default' : 'disabled'}>
       수정하기
     </Button>
   )

--- a/src/components/withdraw-screen/withdraw-reason-field.tsx
+++ b/src/components/withdraw-screen/withdraw-reason-field.tsx
@@ -1,3 +1,4 @@
+import Required from '@/components/common/required'
 import { WithDrawnFormState } from '@/pages/my-page/withdraw'
 import { UseFormRegister } from 'react-hook-form'
 
@@ -9,7 +10,7 @@ function WithdrawReasonField({ register }: WithdrawReasonFieldProps) {
   return (
     <section className="flex flex-col gap-4 px-4 py-6">
       <h3 className="flex items-center self-start font-bold">
-        탈퇴 이유를 선택해주세요 <span className="text-error ml-1">*</span>
+        탈퇴 이유를 선택해주세요 <Required />
       </h3>
       <ul className="flex flex-col gap-5">
         {reasons.map((el, index) => (

--- a/src/pages/my-page/withdraw.tsx
+++ b/src/pages/my-page/withdraw.tsx
@@ -44,8 +44,6 @@ function WithDraw() {
   }
 
   const onValid = (data: WithDrawnFormState) => {
-    console.log('hi')
-
     if (!cautionIsChecked) {
       toast.error('동의 항목에 체크해 주세요.')
       return

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -90,7 +90,11 @@ const Signup = () => {
               />
             )}
           ></Controller>
-          <Button type="submit" className="mt-auto">
+          <Button
+            type="submit"
+            className="mt-auto"
+            variant={isNicknameDuplicated ? 'default' : 'disabled'}
+          >
             제출
           </Button>
         </form>


### PR DESCRIPTION
## 🔗 관련 이슈 : #149 

## 📌 개요
TS035 bugfix 작업입니다.
회원가입 페이지와, 회원 정보 수정 페이지에서 사용하는 InputNickname 컴포넌트와 제출버튼의 default ui를 기획안과 동일시 하는 작업입니다.

## 🔍 작업 유형
- [ ] 기능 추가 (feat)
- [x] 버그 수정 (fix) <!-- 엔드 유저를 위한 버그 픽스, 필드스크립트 등 개발자를 위한 버그 픽스는 포함 X -->
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 코드 포맷팅 (style) <!-- 세미콜론, 들여쓰기, 공백 등 (프로덕션 코드 변경사항 X) -->
- [ ] 그 외 잡일 (chore) <!-- 패키지 설치, 개발도구 설정 등 (프로덕션 코드 변경사항 X) -->
- [ ] 테스트 코드 추가 또는 수정 (test)
- [ ] CI/CD (ci)

## 🧩 작업 상세
1. 중복 확인 버튼의 기본 색상을 bg-gray에서 mountain으로 바꾸었습니다.
2. <Button disabled={...}> 처럼 기본 HTML disabled 속성을 직접 쓰는 대신, variant="disabled" 같은 CVA(variants) 기반 스타일 변형을 통해 버튼을 비활성화된 것처럼 보이도록 처리했습니다.

## 🖼️ 화면 스크린샷 (Optional)

https://github.com/user-attachments/assets/991fe001-876e-44a8-b9de-9ed1975644b8

