### PR TITLE
fix: withdraw body typo and ResultNoticeDialog onConfirm

### DIFF
--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -65,10 +65,10 @@ export const usersApi = {
       },
     })
   },
-  withdraw: async ({ reasonType, customReason }: WithDrawnFormState) => {
+  withdraw: async ({ reasonTypes, customReason }: WithDrawnFormState) => {
     return fetch(`${API_URL}/members/withdraw`, {
       method: 'POST',
-      body: JSON.stringify({ reasonType, customReason }),
+      body: JSON.stringify({ reasonTypes, customReason }),
       headers: {
         'Content-Type': 'application/json',
       },

--- a/src/components/withdraw-screen/withdraw-reason-field.tsx
+++ b/src/components/withdraw-screen/withdraw-reason-field.tsx
@@ -20,7 +20,7 @@ function WithdrawReasonField({ register }: WithdrawReasonFieldProps) {
                 type="checkbox"
                 className="peer hidden"
                 value={el.name}
-                {...register('reasonType', {
+                {...register('reasonTypes', {
                   validate: (v) =>
                     (Array.isArray(v) && v.length > 0) || '탈퇴 이유를 하나 이상 선택해주세요.',
                 })}
@@ -39,7 +39,7 @@ function WithdrawReasonField({ register }: WithdrawReasonFieldProps) {
                 placeholder="기타 이유를 입력해주세요"
                 {...register('customReason', {
                   validate: (value, formValues) => {
-                    const list = Array.from(formValues.reasonType)
+                    const list = Array.from(formValues.reasonTypes)
                     return list.includes('OTHER')
                       ? !!value?.trim() || '기타 이유를 입력해주세요.'
                       : true

--- a/src/routes/my-page/withdraw.tsx
+++ b/src/routes/my-page/withdraw.tsx
@@ -31,13 +31,14 @@ function WithDraw() {
     const res = await usersApi.withdraw(dataRef.current)
 
     if (res.success) {
-      initHistoryAndLocation()
       setShowConfirmModal(false)
       setShowNoticeModal(true)
     }
   }
 
   const onValid = (data: WithDrawnFormState) => {
+    console.log(data)
+
     if (!cautionIsChecked) {
       toast.error('동의 항목에 체크해 주세요.')
       return
@@ -48,8 +49,8 @@ function WithDraw() {
   }
 
   const onInvalid = (errors: FieldErrors<WithDrawnFormState>) => {
-    if (errors.reasonType) {
-      toast.error(errors.reasonType.message)
+    if (errors.reasonTypes) {
+      toast.error(errors.reasonTypes.message)
     }
     if (errors.customReason) {
       toast.error(errors.customReason.message)
@@ -83,7 +84,10 @@ function WithDraw() {
           isOpen={showNoticeModal}
           setIsOpen={setShowNoticeModal}
           description={`회원 탈퇴가\n정상적으로 완료되었습니다.`}
-          onConfirm={() => setShowNoticeModal(false)}
+          onConfirm={() => {
+            initHistoryAndLocation()
+            setShowNoticeModal(false)
+          }}
         />
       )}
     </>

--- a/src/types/withdraw.ts
+++ b/src/types/withdraw.ts
@@ -1,4 +1,4 @@
 export interface WithDrawnFormState {
-  reasonType: string | string[]
+  reasonTypes: string[]
   customReason: string | null
 }


### PR DESCRIPTION
## 🔗 관련 이슈 : #158 

## 📌 개요
회원탈퇴 api body가 reasontypes로 가야하는데 resonType으로 가고 있어 발생한 버그 개선 작업입니다.

## 🔍 작업 유형
- [ ] 기능 추가 (feat)
- [x] 버그 수정 (fix) <!-- 엔드 유저를 위한 버그 픽스, 필드스크립트 등 개발자를 위한 버그 픽스는 포함 X -->
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 코드 포맷팅 (style) <!-- 세미콜론, 들여쓰기, 공백 등 (프로덕션 코드 변경사항 X) -->
- [ ] 그 외 잡일 (chore) <!-- 패키지 설치, 개발도구 설정 등 (프로덕션 코드 변경사항 X) -->
- [ ] 테스트 코드 추가 또는 수정 (test)
- [ ] CI/CD (ci)

## 🧩 작업 상세
1. resonType을 모두 resonTypes로 바꾸어주었습니다.
2. initHistoryAndLocation()를 ResultNoticeDialog에서 확인 버튼을 눌러야지만 실행되게 했습니다. 이유는 확인을 누르기 전에 setTimout으로 reload가 되버리는 상황이 발생하기 떄문입니다.