### PR TITLE
[Feat] usercard profile image

### DIFF
--- a/src/components/common/logo-icon.tsx
+++ b/src/components/common/logo-icon.tsx
@@ -2,13 +2,17 @@ import { cn } from '@/lib/utils'
 import { cva, VariantProps } from 'class-variance-authority'
 
 const logoIconVariants = cva(
-  'h-[92px] w-[92px] rounded-full border-2 border-gray-300 bg-[url("/img/logo-icon.png")] bg-cover bg-size-[50px] bg-no-repeat [background-position-x:center] [background-position-y:center]',
+  'h-[92px] w-[92px] rounded-full border-2 border-gray-300 bg-no-repeat [background-position-x:center] [background-position-y:center]',
   {
     variants: {
       size: {
         small: 'h-[20px] w-[20px] bg-contain',
         medium: 'h-[46px] w-[46px] bg-contain',
         large: 'h-[92px] w-[92px]',
+      },
+      type: {
+        logo: 'bg-[url("/img/logo-icon.png")] bg-cover bg-size-[50px]',
+        profile: 'bg-cover bg-center',
       },
     },
     defaultVariants: {
@@ -17,10 +21,21 @@ const logoIconVariants = cva(
   },
 )
 
-type LogoIconProps = VariantProps<typeof logoIconVariants> & React.HTMLAttributes<HTMLDivElement>
+type LogoIconProps = VariantProps<typeof logoIconVariants> &
+  React.HTMLAttributes<HTMLDivElement> & {
+    profileImage?: string | null
+  }
 
-const LogoIcon = ({ className, size, ...props }: LogoIconProps) => {
-  return <div className={cn(logoIconVariants({ size }), className)} {...props} />
+const LogoIcon = ({ className, size, profileImage, ...props }: LogoIconProps) => {
+  const type = profileImage ? 'profile' : 'logo'
+
+  return (
+    <div
+      className={cn(logoIconVariants({ size, type }), className)}
+      style={profileImage ? { backgroundImage: `url(${profileImage})` } : undefined}
+      {...props}
+    />
+  )
 }
 
 export default LogoIcon

--- a/src/components/common/user-card.tsx
+++ b/src/components/common/user-card.tsx
@@ -5,6 +5,7 @@ import { Separator } from '@/components/shadcn/separator'
 import useUserName from '@/hooks/use-user-name'
 import { authStore } from '@/store/auth-store'
 import useUserEmail from '@/hooks/use-user-email'
+import useUserProfileImageUrl from '@/hooks/use-user-profile-image-url'
 
 const UserCard = () => {
   const navigate = useNavigate()
@@ -12,6 +13,7 @@ const UserCard = () => {
   const accessToken = authStore((state) => state.accessToken)
   const userName = useUserName()
   const userEmail = useUserEmail()
+  const userProfileImageUrl = useUserProfileImageUrl()
 
   const handleLoginClick = () => {
     navigate({ to: '/login' })
@@ -42,7 +44,7 @@ const UserCard = () => {
   return (
     <div className="border-lighter-gray-border flex flex-col items-center rounded-2xl border bg-white">
       <div className="flex w-full items-center gap-8 px-5 py-4">
-        <LogoIcon size="large" />
+        <LogoIcon size="large" profileImage={userProfileImageUrl} />
         {!userName ? (
           <button onClick={handleLoginClick} className="text-start text-lg font-bold">
             로그인이 필요합니다.

--- a/src/hooks/use-user-profile-image-url.ts
+++ b/src/hooks/use-user-profile-image-url.ts
@@ -1,0 +1,8 @@
+import useUserMe from './use-user-me'
+
+const useUserProfileImageUrl = () => {
+  const { data } = useUserMe()
+  return data?.result?.profileImageUrl ?? null
+}
+
+export default useUserProfileImageUrl

--- a/src/routes/my-page/withdraw.tsx
+++ b/src/routes/my-page/withdraw.tsx
@@ -37,8 +37,6 @@ function WithDraw() {
   }
 
   const onValid = (data: WithDrawnFormState) => {
-    console.log(data)
-
     if (!cautionIsChecked) {
       toast.error('동의 항목에 체크해 주세요.')
       return


### PR DESCRIPTION
## 🔗 관련 이슈 : #196 

## 📌 개요
UseCard, 정확히는 LogoIcon에 사용자 profileImage가 보이도록 하는 작업입니다. 

## 🔍 작업 유형
- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix) <!-- 엔드 유저를 위한 버그 픽스, 필드스크립트 등 개발자를 위한 버그 픽스는 포함 X -->
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 코드 포맷팅 (style) <!-- 세미콜론, 들여쓰기, 공백 등 (프로덕션 코드 변경사항 X) -->
- [ ] 그 외 잡일 (chore) <!-- 패키지 설치, 개발도구 설정 등 (프로덕션 코드 변경사항 X) -->
- [ ] 테스트 코드 추가 또는 수정 (test)
- [ ] CI/CD (ci)

## 🧩 작업 상세
1. useUserMe에서 profileImageUrl만 뺴오는 useUserProfileImageUrl hook을 추가했습니다.
2. LogoIcon 컴포넌트에 profileImage prop을 추가했습니다. profileImage이 존재하면 로고가 아닌 image가 뜨도록 합니다.

## 🖼️ 화면 스크린샷 (Optional)
https://github.com/user-attachments/assets/253695ba-4e1f-4b1f-b53b-1a2a12cf9ae7

## 💬 리뷰 요구사항 (Optional)
1. 프로필 사진을 upload 할때 어떤 ux flow가 바람직하다고 생각하시는지 궁금합니다! 예시로 github는 사용자가 이미지를 업로드하면 모달이 떠서 규격에 맞게 자르도록 강제하는 flow입니다. 아니면 아예 imageInput에서 특정 규격에 맞지 않으면 다시 올리도록 error message를 띄우는 방법도 있을 것 같습니다

