### PR TITLE
[fix] point-exchange-dialog fix design

### DIFF
--- a/src/components/common/modal/confirm-dialog.tsx
+++ b/src/components/common/modal/confirm-dialog.tsx
@@ -10,7 +10,7 @@ import { Button } from '@/components/common/button'
 type ConfirmDialogProps = {
   isOpen: boolean
   title?: string
-  description: string
+  description: string | React.ReactNode
   paragraph?: string
   setIsOpen: (open: boolean) => void
   onConfirm: () => void

--- a/src/components/common/modal/notice-dialog.tsx
+++ b/src/components/common/modal/notice-dialog.tsx
@@ -11,7 +11,7 @@ import React from 'react'
 interface NoticeDialogProps {
   isOpen: boolean
   title?: string
-  description: string
+  description: string | React.ReactNode
   paragraph?: string
   setIsOpen: (open: boolean) => void
   onConfirm: () => void
@@ -34,12 +34,7 @@ function NoticeDialog({
           </DialogTitle>
         )}
         <DialogDescription className="text-secondary-foreground flex flex-col items-center justify-center text-center text-base whitespace-pre-line">
-          {description.split('\\n').map((line, index) => (
-            <React.Fragment key={index}>
-              {line}
-              {index < description.split('\\n').length - 1 && <br />}
-            </React.Fragment>
-          ))}
+          {description}
           {paragraph && <p className="text-lighter-gray text-xs">{paragraph}</p>}
         </DialogDescription>
         <DialogFooter className="flex flex-row items-center gap-4 sm:justify-center">

--- a/src/components/shop-screen/point-description.tsx
+++ b/src/components/shop-screen/point-description.tsx
@@ -52,7 +52,7 @@ const PointDescription = ({
       />
       <PointOverview label="차감 포인트" point={`${deductPoint}p`} valueClassName="text-red-500" />
       <PointOverview
-        label="총 보유 포인트"
+        label="남은 포인트"
         point={textIfDoneExchangingPoint}
         valueClassName="text-mountain_meadow"
       />

--- a/src/routes/point-shop/products/$point-product-id/detail.tsx
+++ b/src/routes/point-shop/products/$point-product-id/detail.tsx
@@ -112,20 +112,35 @@ function ProductDetail() {
           <ConfirmDialog
             isOpen={showConfirmDialog}
             setIsOpen={setShowConfirmDialog}
-            description={`이름 ${user?.name}\n 전화번호 ${user?.phone}\n 주소 ${user?.address.roadAddress}\n ${user?.address.detailAddress}`}
-            paragraph="수정이 불가능하니 리워드 수령 정보를 다시 확인해주세요."
+            description={
+              <div className="p-4 text-left">
+                <div>
+                  <strong>이름:</strong> {user?.name}
+                </div>
+                <div>
+                  <strong>전화번호:</strong> {user?.phone}
+                </div>
+                <div>
+                  <strong>주소:</strong> {user?.address.roadAddress}
+                </div>
+                <div>{user?.address.detailAddress}</div>
+              </div>
+            }
+            paragraph={`수정이 불가능하니\n 리워드 수령 정보를 다시 확인해주세요.`}
             onConfirm={handleConfirm}
             isPending={isExchanging}
           />
           <NoticeDialog
             isOpen={showNoticeDialog}
             setIsOpen={setShowNoticeDialog}
-            description={`
-              교환 신청이 완료되었습니다!\n
-              [마이페이지] -> [포인트내역]에서\n
-              확인할 수 있어요\n
-              배송까지 소요될 예정입니다.\n
-            `}
+            description={
+              <div className="p-4">
+                <p>교환 신청이 완료되었습니다!</p>
+                <p>[마이페이지] -{'>'} [포인트내역]에서</p>
+                <p>확인할 수 있어요</p>
+                <p>배송까지 2~3일 소요될 예정입니다.</p>
+              </div>
+            }
             onConfirm={handleExchange}
           />
         </PageLayOut.BodySection>


### PR DESCRIPTION
## 🔗 관련 이슈 : #209

## 📌 개요

- 포인트 교환 주소지 확인 모달과 교환 안내 모달을 description 내용 수정
- 총 보유 포인트 -> 남은 포인트로 수정

## 🔍 작업 유형

- [ ] 기능 추가 (feat)
- [x] 버그 수정 (fix) <!-- 엔드 유저를 위한 버그 픽스, 필드스크립트 등 개발자를 위한 버그 픽스는 포함 X -->
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 코드 포맷팅 (style) <!-- 세미콜론, 들여쓰기, 공백 등 (프로덕션 코드 변경사항 X) -->
- [ ] 그 외 잡일 (chore) <!-- 패키지 설치, 개발도구 설정 등 (프로덕션 코드 변경사항 X) -->
- [ ] 테스트 코드 추가 또는 수정 (test)
- [ ] CI/CD (ci)

## 🧩 작업 상세
두 가지 dialog의 description 타입에 ReactNode를 허용함으로써 내부에 세부 스타일링을 가져갈 수 있도록 하였습니다.
```
/* *-dialog.tsx */
description: string | React.ReactNode
```

## 🖼️ 화면 스크린샷 (Optional)
<img width="200" height="200" alt="image" src="https://github.com/user-attachments/assets/0df7a37c-22f4-45a9-a296-6f13751fe97b" />
<img width="200" height="200" alt="image" src="https://github.com/user-attachments/assets/90479b34-8ef2-46b5-9997-09ed888c2604" />

## 💬 리뷰 요구사항 (Optional)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요. -->
