### PR TITLE
fix: ts015 + apply comment

### DIFF
--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -4,6 +4,7 @@ import { WithDrawnFormState } from '@/types/withdraw'
 import { ApiResponse } from '@/types/api'
 import { PointFilterType, PointHistory } from '@/types/points'
 import { createQueryKeys, mergeQueryKeys } from '@lukemorales/query-key-factory'
+import { throwResponseStatusThenChaining } from '@/lib/network'
 
 export const usersApi = {
   getUserStatus: async () => {
@@ -22,17 +23,16 @@ export const usersApi = {
     )
     return response.json() as Promise<GetMyPointsHistoryResponse>
   },
-  putUserProfile: async (
-    nickname: string | null,
-    profileImageUrl = 'https://www.greenwinit.store/img/logo-icon.png',
-  ) => {
+  putUserProfile: async (nickname: string | null, profileImageUrl: string | null) => {
     return await fetch(`${API_URL}/members/profile`, {
       method: 'PUT',
       body: JSON.stringify({ nickname, profileImageUrl }),
       headers: {
         'Content-Type': 'application/json',
       },
-    }).then((res) => res.json() as Promise<PutUserProfileResponse>)
+    })
+      .then(throwResponseStatusThenChaining)
+      .then((res) => res.json() as Promise<PutUserProfileResponse>)
   },
   checkNicknameDuplicate: async (nickname: string) => {
     return await fetch(`${API_URL}/members/nickname-check`, {


### PR DESCRIPTION
## 🔗 관련 이슈 : #212 

## 📌 개요
ts015 fix 작업과 코멘트 반영 작업입니다.

## 🔍 작업 유형
- [] 기능 추가 (feat)
- [x] 버그 수정 (fix) <!-- 엔드 유저를 위한 버그 픽스, 필드스크립트 등 개발자를 위한 버그 픽스는 포함 X -->
- [x] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 코드 포맷팅 (style) <!-- 세미콜론, 들여쓰기, 공백 등 (프로덕션 코드 변경사항 X) -->
- [ ] 그 외 잡일 (chore) <!-- 패키지 설치, 개발도구 설정 등 (프로덕션 코드 변경사항 X) -->
- [ ] 테스트 코드 추가 또는 수정 (test)
- [ ] CI/CD (ci)

## 🧩 작업 상세
1. 사용자가 이미지를 변경하지 않고 제출하는 경우, 하드코딩된 url이 아닌 null이 가도록 했습니다.
2. 이전에 코멘트 주신 내용을 바탕으로 putUserProfile에서는 200 status가 아닐시 error를 throw하고 useMutation의 onErorr에서 toast 를 띄우도록 했습니다.
3. RHF에게 상태관리를 전담시켰음에도 불구하고 불필요하게 정의 되어 있던 chagesField를 없애고, formState.dirtyFiels로 관리하도록 수정했습니다.