### PR TITLE
fix: rename 제목없음 to challengeName

### DIFF
--- a/src/components/my-page-screen/certified-challenges-container.tsx
+++ b/src/components/my-page-screen/certified-challenges-container.tsx
@@ -1,11 +1,12 @@
 import { useNavigate } from '@tanstack/react-router'
 import FilteredChallengesDisplay from '@/components/filtered-challenges-display'
 import { useCertifiedChallenges } from '@/hooks/challenge/use-certified-challenges'
+import Loading from '@/components/common/loading'
 
 function CertifiedChallengesContainer() {
   const navigate = useNavigate()
   const { challengeType, setChallengeType, data, isLoading } = useCertifiedChallenges()
-  if (isLoading) return <div>데이터 불러오는 중...</div>
+  if (isLoading) return <Loading />
 
   const challenges = data?.result?.content
   if (!challenges) return <div>인증한 챌린지가 없습니다.</div>

--- a/src/routes/my-page/challenges/certify/$challenge-id.tsx
+++ b/src/routes/my-page/challenges/certify/$challenge-id.tsx
@@ -2,6 +2,7 @@ import { useCertifiedChallengeDetails } from '@/hooks/challenge/use-certified-ch
 import Row from '@/components/common/form/row'
 import MyPageLayout from '@/components/my-page-screen/my-page-layout'
 import { createFileRoute } from '@tanstack/react-router'
+import Loading from '@/components/common/loading'
 
 export const Route = createFileRoute('/my-page/challenges/certify/$challenge-id')({
   component: CertifiedChallengeDetails,
@@ -11,7 +12,7 @@ function CertifiedChallengeDetails() {
   const challengeId = Number(Route.useParams()['challenge-id'])
   const { data, isLoading } = useCertifiedChallengeDetails(Number(challengeId))
 
-  if (isLoading) return <div>데이터를 불러오는 중...</div>
+  if (isLoading) return <Loading />
 
   const info = data?.result
   if (!info) return <div>데이터가 없습니다.</div>
@@ -22,8 +23,7 @@ function CertifiedChallengeDetails() {
         <Row>
           <h3>제목</h3>
           <div className="w-full rounded-[10px] border border-[#c0c0c0] bg-white p-4 text-start">
-            {/* @TODO info.title 생기면 '제목 없음' 대체할 예정 */}
-            <span className="text-secondary-foreground text-base">제목 없음</span>
+            <span className="text-secondary-foreground text-base">{data.result.challengeName}</span>
           </div>
         </Row>
         <Row>


### PR DESCRIPTION
## 🔗 관련 이슈 : #214 

## 📌 개요
인증 챌린지 화면에 "제목없음"이라고 보이는 부분을 개선한 작업입니다.

## 🔍 작업 유형
- [ ] 기능 추가 (feat)
- [x] 버그 수정 (fix) <!-- 엔드 유저를 위한 버그 픽스, 필드스크립트 등 개발자를 위한 버그 픽스는 포함 X -->
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 코드 포맷팅 (style) <!-- 세미콜론, 들여쓰기, 공백 등 (프로덕션 코드 변경사항 X) -->
- [ ] 그 외 잡일 (chore) <!-- 패키지 설치, 개발도구 설정 등 (프로덕션 코드 변경사항 X) -->
- [ ] 테스트 코드 추가 또는 수정 (test)
- [ ] CI/CD (ci)

## 🧩 작업 상세
그 밖에 isLoading 일 때 데이터가 없습니다가 아닌 Loading 컴포넌트가 렌더링 되게 했습니다.