### PR TITLE
refactor: restructure some API calls to useMutation

### DIFF
--- a/src/api/images.ts
+++ b/src/api/images.ts
@@ -1,4 +1,5 @@
 import { API_URL } from '@/constant/network'
+import { throwResponseStatusThenChaining } from '@/lib/network'
 
 export const imagesApi = {
   uploadImage: async (
@@ -7,23 +8,18 @@ export const imagesApi = {
   ) => {
     const formData = new FormData()
     formData.append('imageFile', file)
-    const response = await fetch(`${API_URL}/images?purpose=${purpose}`, {
+    await fetch(`${API_URL}/images?purpose=${purpose}`, {
       method: 'POST',
       body: formData,
     })
-    return response.json() as Promise<{
-      /**
-       * '이미지 업로드에 성공했습니다.'
-       */
-      message: string
-      /**
-       * 'https://static.greenwinit.store/images/profile/8d/20250727/d93917a6_1753638663985.png'
-       */
-      result: string
-      /**
-       * true
-       */
-      success: boolean
-    }>
+      .then(throwResponseStatusThenChaining)
+      .then(
+        (res) =>
+          res.json() as Promise<{
+            message: string
+            result: string
+            success: boolean
+          }>,
+      )
   },
 }

--- a/src/api/images.ts
+++ b/src/api/images.ts
@@ -1,5 +1,4 @@
 import { API_URL } from '@/constant/network'
-import { throwResponseStatusThenChaining } from '@/lib/network'
 
 export const imagesApi = {
   uploadImage: async (
@@ -8,18 +7,23 @@ export const imagesApi = {
   ) => {
     const formData = new FormData()
     formData.append('imageFile', file)
-    await fetch(`${API_URL}/images?purpose=${purpose}`, {
+    const response = await fetch(`${API_URL}/images?purpose=${purpose}`, {
       method: 'POST',
       body: formData,
     })
-      .then(throwResponseStatusThenChaining)
-      .then(
-        (res) =>
-          res.json() as Promise<{
-            message: string
-            result: string
-            success: boolean
-          }>,
-      )
+    return response.json() as Promise<{
+      /**
+       * '이미지 업로드에 성공했습니다.'
+       */
+      message: string
+      /**
+       * 'https://static.greenwinit.store/images/profile/8d/20250727/d93917a6_1753638663985.png'
+       */
+      result: string
+      /**
+       * true
+       */
+      success: boolean
+    }>
   },
 }

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -4,6 +4,7 @@ import { WithDrawnFormState } from '@/types/withdraw'
 import { ApiResponse } from '@/types/api'
 import { PointFilterType, PointHistory } from '@/types/points'
 import { createQueryKeys, mergeQueryKeys } from '@lukemorales/query-key-factory'
+import { throwResponseStatusThenChaining } from '@/lib/network'
 
 export const usersApi = {
   getUserStatus: async () => {
@@ -32,7 +33,9 @@ export const usersApi = {
       headers: {
         'Content-Type': 'application/json',
       },
-    }).then((res) => res.json() as Promise<PutUserProfileResponse>)
+    })
+      .then(throwResponseStatusThenChaining)
+      .then((res) => res.json() as Promise<PutUserProfileResponse>)
   },
   checkNicknameDuplicate: async (nickname: string) => {
     return await fetch(`${API_URL}/members/nickname-check`, {
@@ -41,7 +44,9 @@ export const usersApi = {
       headers: {
         'Content-Type': 'application/json',
       },
-    }).then((res) => res.json() as Promise<CheckNicknameDuplicateReponse>)
+    })
+      .then(throwResponseStatusThenChaining)
+      .then((res) => res.json() as Promise<CheckNicknameDuplicateReponse>)
   },
   logout: async () => {
     return fetch(`${API_URL}/auth/logout`, {
@@ -72,7 +77,9 @@ export const usersApi = {
       headers: {
         'Content-Type': 'application/json',
       },
-    }).then((res) => res.json() as Promise<PostWithdrawResponse>)
+    })
+      .then(throwResponseStatusThenChaining)
+      .then((res) => res.json() as Promise<PostWithdrawResponse>)
   },
   getUserMe: async () => {
     const response = await fetch(`${API_URL}/members/me`)

--- a/src/routes/my-page/withdraw.tsx
+++ b/src/routes/my-page/withdraw.tsx
@@ -12,6 +12,8 @@ import { toast } from 'sonner'
 import { Button } from '@/components/common/button'
 import { createFileRoute } from '@tanstack/react-router'
 import { WithDrawnFormState } from '@/types/withdraw'
+import { useMutation } from '@tanstack/react-query'
+import { showMessageIfExists } from '@/lib/error'
 
 export const Route = createFileRoute('/my-page/withdraw')({
   component: WithDraw,
@@ -25,15 +27,21 @@ function WithDraw() {
 
   const { register, handleSubmit } = useForm<WithDrawnFormState>()
 
-  const onConfirm = async () => {
-    if (!dataRef.current) return
-
-    const res = await usersApi.withdraw(dataRef.current)
-
-    if (res.success) {
+  const { mutateAsync: withdraw } = useMutation({
+    mutationFn: (data: WithDrawnFormState) => usersApi.withdraw(data),
+    onSuccess: () => {
       setShowConfirmModal(false)
       setShowNoticeModal(true)
-    }
+    },
+    onError: (err: Error) => {
+      console.error(err)
+      showMessageIfExists(err)
+    },
+  })
+
+  const onConfirm = async () => {
+    if (!dataRef.current) return
+    await withdraw(dataRef.current)
   }
 
   const onValid = (data: WithDrawnFormState) => {


### PR DESCRIPTION
## 🔗 관련 이슈 : #208 

## 📌 개요
마이페이지를 작업하면서 만든 api 혹 호출 함수에서 .then(throwResponseStatusThenChaining)에서 건넨 error를 useMutation의 onError가 핸들링 하도록 구조를 개선한 작업입니다. 

## 🔍 작업 유형
- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix) <!-- 엔드 유저를 위한 버그 픽스, 필드스크립트 등 개발자를 위한 버그 픽스는 포함 X -->
- [x] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 코드 포맷팅 (style) <!-- 세미콜론, 들여쓰기, 공백 등 (프로덕션 코드 변경사항 X) -->
- [ ] 그 외 잡일 (chore) <!-- 패키지 설치, 개발도구 설정 등 (프로덕션 코드 변경사항 X) -->
- [ ] 테스트 코드 추가 또는 수정 (test)
- [ ] CI/CD (ci)