### PR TITLE
[Fix] solve QA problem

### DIFF
--- a/src/components/shop-screen/exchange-product.tsx
+++ b/src/components/shop-screen/exchange-product.tsx
@@ -4,11 +4,17 @@ import { Button } from '@/components/common/button'
 interface ExchangeProductProps {
   availablePoint: number
   deductPoint: number
+  remainingQuantity: number | undefined
   handleClick: () => void
 }
 
-const ExchangeProduct = ({ availablePoint, deductPoint, handleClick }: ExchangeProductProps) => {
-  const isDisabled = availablePoint < deductPoint
+const ExchangeProduct = ({
+  availablePoint,
+  deductPoint,
+  remainingQuantity,
+  handleClick,
+}: ExchangeProductProps) => {
+  const isDisabled = availablePoint < deductPoint || remainingQuantity === 0
 
   return (
     <div className="w-full">

--- a/src/components/shop-screen/user-statusbar.tsx
+++ b/src/components/shop-screen/user-statusbar.tsx
@@ -16,7 +16,7 @@ const UserStatusbar = ({ point, availablePoint }: UserStatusbarProps) => {
     <div className="flex w-full flex-col items-center">
       <div className="flex w-full items-center justify-between px-4 pt-4">
         <div className="flex flex-col items-baseline">
-          <p className="mb-1 text-xs text-gray-500">나의 포인트</p>
+          <p className="mb-1 text-xs text-gray-500">총 누적 포인트</p>
           <p className="text-2xl font-semibold text-black">{point}</p>
         </div>
         <button

--- a/src/routes/point-shop/products/$point-product-id/detail.tsx
+++ b/src/routes/point-shop/products/$point-product-id/detail.tsx
@@ -114,17 +114,13 @@ function ProductDetail() {
             isOpen={showConfirmDialog}
             setIsOpen={setShowConfirmDialog}
             description={
-              <div className="p-4 text-left">
-                <div>
-                  <strong>이름:</strong> {user?.name}
-                </div>
-                <div>
-                  <strong>전화번호:</strong> {user?.phone}
-                </div>
-                <div>
-                  <strong>주소:</strong> {user?.address.roadAddress}
-                </div>
-                <div>{user?.address.detailAddress}</div>
+              <div className="mb-4 w-48 text-left">
+                <p>
+                  <strong>이름:</strong> {user?.name} <br />
+                  <strong>전화번호:</strong> {user?.phone} <br />
+                  <strong>주소:</strong> {`${user?.address.roadAddress} `}
+                  {user?.address.detailAddress}
+                </p>
               </div>
             }
             paragraph={`수정이 불가능하니\n 리워드 수령 정보를 다시 확인해주세요.`}
@@ -135,11 +131,14 @@ function ProductDetail() {
             isOpen={showNoticeDialog}
             setIsOpen={setShowNoticeDialog}
             description={
-              <div>
-                <p className="mb-4 text-xl font-bold">교환 신청이 완료되었습니다!</p>
-                <p>[마이페이지] -{'>'} [포인트 현황]에서</p>
-                <p className="mb-4">확인할 수 있어요</p>
-                <p>배송까지 약 3~7일 소요될 예정입니다.</p>
+              <div className="w-48">
+                <p className="mb-4 font-bold whitespace-nowrap">교환 신청이 완료되었습니다!</p>
+                <p className="mb-4 text-xs">
+                  [마이페이지] -{'>'} [포인트 현황]에서
+                  <br />
+                  확인할 수 있어요
+                </p>
+                <p className="text-xs">배송까지 약 3~7일 소요될 예정입니다.</p>
               </div>
             }
             onConfirm={handleExchange}

--- a/src/routes/point-shop/products/$point-product-id/detail.tsx
+++ b/src/routes/point-shop/products/$point-product-id/detail.tsx
@@ -108,6 +108,7 @@ function ProductDetail() {
             availablePoint={availablePoint}
             deductPoint={deductPoint}
             handleClick={handleExchangeButton}
+            remainingQuantity={product?.stockQuantity}
           />
           <ConfirmDialog
             isOpen={showConfirmDialog}

--- a/src/routes/point-shop/products/$point-product-id/enroll-address.tsx
+++ b/src/routes/point-shop/products/$point-product-id/enroll-address.tsx
@@ -172,7 +172,15 @@ function EnrollAddress() {
           {isModalOpen && (
             <NoticeDialog
               isOpen={isModalOpen}
-              description="배송지 저장이 완료되었습니다.\n이제 상품을 교환할 수 있습니다!"
+              description={
+                <div className="p-2 text-center">
+                  <p>
+                    배송지 저장이 완료되었습니다.
+                    <br />
+                    이제 상품을 교환할 수 있습니다!
+                  </p>
+                </div>
+              }
               setIsOpen={setIsModalOpen}
               onConfirm={handleConfirm}
             />


### PR DESCRIPTION
## 🔗 관련 이슈 : #243 

## 📌 개요

QA 후, 요청 사항 대로 포인트 샵에서 사용하는 모달 사이즈와 문구, 교환하기 버튼 비활성화 조건 추가를 적용하였습니다

## 🔍 작업 유형

- [ ] 기능 추가 (feat)
- [x] 버그 수정 (fix) <!-- 엔드 유저를 위한 버그 픽스, 필드스크립트 등 개발자를 위한 버그 픽스는 포함 X -->
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 코드 포맷팅 (style) <!-- 세미콜론, 들여쓰기, 공백 등 (프로덕션 코드 변경사항 X) -->
- [ ] 그 외 잡일 (chore) <!-- 패키지 설치, 개발도구 설정 등 (프로덕션 코드 변경사항 X) -->
- [ ] 테스트 코드 추가 또는 수정 (test)
- [ ] CI/CD (ci)

## 🧩 작업 상세

모달의 description 안에 태그들을 넣다 보니 375화면에 맞는 고정 사이즈 w-48을 적용하는 거 외에는 방법이 떠오르질 않아서
고정 사이즈를 적용했습니다 화면이 줄어들게 되면 짤리는 현상이 발생합니다. 그리고 같은 너비임에도 내부 태그노드 들이 달라서 그런지 모달 화면의 크기가 약간 다릅니다
(너비 300까지는 어색하지 않습니다...) 

이부분은 고려 안해도 된다 해서 일단 이렇게 pr을 올리게 되었습니다.

## 🖼️ 화면 스크린샷 (Optional)

<img width="375" height="540" alt="image" src="https://github.com/user-attachments/assets/f1487022-87f5-463f-9820-1bf7d81f6c86" />
<img width="375" height="540" alt="image" src="https://github.com/user-attachments/assets/ddf38a49-966a-49a8-83ed-f4196213219e" />


## 💬 리뷰 요구사항 (Optional)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요. -->
