### PR TITLE
refactor: member api, member-certification api migration

### DIFF
--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -36,7 +36,7 @@ export const usersApi = {
       .then((res) => res.json() as Promise<PutUserProfileResponse>)
   },
   checkNicknameDuplicate: async (nickname: string) => {
-    return await fetch(`${API_URL}/members/nickname-check`, {
+    return await fetch(`${API_URL}/members/v2/nickname-check`, {
       method: 'POST',
       body: JSON.stringify({ nickname }),
       headers: {
@@ -47,9 +47,13 @@ export const usersApi = {
       .then((res) => res.json() as Promise<CheckNicknameDuplicateReponse>)
   },
   logout: async () => {
-    return fetch(`${API_URL}/auth/logout`, {
+    return fetch(`${API_URL}/auth/v2/logout`, {
       method: 'POST',
     })
+      .then(throwResponseStatusThenChaining)
+      .then((res) => {
+        return res.json() as Promise<ApiResponse<null>>
+      })
   },
   signup: async ({
     tempToken,
@@ -60,7 +64,7 @@ export const usersApi = {
     nickname: string
     profileImageUrl: string | null
   }) => {
-    return fetch(`${API_URL}/auth/signup`, {
+    return fetch(`${API_URL}/auth/v2/signup`, {
       method: 'POST',
       body: JSON.stringify({ tempToken, nickname, profileImageUrl }),
       headers: {
@@ -70,20 +74,16 @@ export const usersApi = {
       .then(throwResponseStatusThenChaining)
       .then((res) => {
         return res.json() as Promise<
-          | {
-              accessToken: string
-              memberKey: string
-              userName: string
-            }
-          | {
-              success: false
-              message: string
-            }
+          ApiResponse<{
+            accessToken: string
+            memberKey: string
+            userName: string
+          }>
         >
       })
   },
   withdraw: async ({ reasonTypes, customReason }: WithDrawnFormState) => {
-    return fetch(`${API_URL}/members/withdraw`, {
+    return fetch(`${API_URL}/members/v2/withdraw`, {
       method: 'POST',
       body: JSON.stringify({ reasonTypes, customReason }),
       headers: {


### PR DESCRIPTION
## 🔗 관련 이슈 : #263 

## 📌 개요
api 및 type migration 작업입니다.

https://discord.com/channels/1364946712967381052/1374691697971171460/1408333024751390791

## 🔍 작업 유형
- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix) <!-- 엔드 유저를 위한 버그 픽스, 필드스크립트 등 개발자를 위한 버그 픽스는 포함 X -->
- [x] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 코드 포맷팅 (style) <!-- 세미콜론, 들여쓰기, 공백 등 (프로덕션 코드 변경사항 X) -->
- [ ] 그 외 잡일 (chore) <!-- 패키지 설치, 개발도구 설정 등 (프로덕션 코드 변경사항 X) -->
- [ ] 테스트 코드 추가 또는 수정 (test)
- [ ] CI/CD (ci)

## 🧩 작업 상세
[인증-클라이언트] 멤버(회원)인증 API, [멤버-클라이언트] 멤버(회원) 관련 API

위에 두개의 api 중  v2 설정이 안되어 있고, 기존에 코드가 존재한 api만 우선 마이그레이션했습니다. 

1)refresh api, 2)logout-all api는 현재 fe에서 정의된게 없는 것 같습니다.  이것은 따로 작업하겠습니다!

