### PR TITLE
fix: add type guard in signup

### DIFF
--- a/src/routes/signup.tsx
+++ b/src/routes/signup.tsx
@@ -68,7 +68,7 @@ function Signup() {
         profileImageUrl: data.profileImage,
       })
       .then((res) => {
-        if ('accessToken' in res) {
+        if ('accessToken' in res && typeof res.accessToken === 'string') {
           setAccessToken(res.accessToken)
         } else {
           throw new Error(res.message)


### PR DESCRIPTION
## 🔗 관련 이슈 : 이슈생성x

## 📌 개요
빌드 에러가 나는 부분 개선 작업입니다. 
signup의 response가 바뀜에 따라 type 호환이 되지 않아, 이를 보완하는 작업입니다.

## 🔍 작업 유형
- [ ] 기능 추가 (feat)
- [x] 버그 수정 (fix) <!-- 엔드 유저를 위한 버그 픽스, 필드스크립트 등 개발자를 위한 버그 픽스는 포함 X -->
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 코드 포맷팅 (style) <!-- 세미콜론, 들여쓰기, 공백 등 (프로덕션 코드 변경사항 X) -->
- [ ] 그 외 잡일 (chore) <!-- 패키지 설치, 개발도구 설정 등 (프로덕션 코드 변경사항 X) -->
- [ ] 테스트 코드 추가 또는 수정 (test)
- [ ] CI/CD (ci)

## 🧩 작업 상세
signup 호출시 `setAccessToken(res.accessToken)`를 하는데 이 때 조건문을 `if ('accessToken' in res && typeof res.accessToken === 'string')` 로 바꾸어 accesstoken이 unknown이 아닌 string일 때에 set이 가능하도록 보완했습니다.
