### PR TITLE
[Feat] Remove initHistoryAndLocation

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -15,19 +15,6 @@ export function formatIsoToDateString(isoString: string): string {
   return `${year}.${month}.${day}`
 }
 
-export function initHistoryAndLocation(to: string = '/') {
-  // 브라우저의 히스토리 스택을 완전히 클리어하고 싶지만,
-  // 해당 방법을 찾지 못했음 (아마 보안상의 이유로 그런 방법이 없는 것으로 추측)
-  // 스택에 루트 두개 넣어서 뒤로가기 버튼 눌러도 루트로 이동하게끔 처리함
-  if (window.location.pathname !== to) {
-    setTimeout(() => {
-      window.location.reload()
-    }, 100)
-  }
-  window.history.pushState(null, '', to)
-  window.history.pushState(null, '', to)
-}
-
 export const serverToClientAddress = (serverAddress: GetServerAddress) => {
   return {
     id: serverAddress.deliveryAddressId,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,6 @@ import './index.css'
 import fetchIntercept, { FetchInterceptorResponse } from 'fetch-intercept'
 import { API_URL } from './constant/network.ts'
 import { authStore } from './store/auth-store.ts'
-import { initHistoryAndLocation } from './lib/utils.ts'
 // Import the generated route tree
 import { routeTree } from './routeTree.gen'
 import { createRouter, RouterProvider } from '@tanstack/react-router'
@@ -117,7 +116,7 @@ fetchIntercept.register({
             .then((body) => {
               if (body.message === '접근이 거부되었습니다.' || body.message.includes('JWT 토큰')) {
                 authStore.getState().initAccessToken()
-                initHistoryAndLocation('/login')
+                router.navigate({ to: '/login' })
               }
             })
         }

--- a/src/routes/my-page/index.tsx
+++ b/src/routes/my-page/index.tsx
@@ -1,7 +1,6 @@
 import { usersApi } from '@/api/users'
 import UserCard from '@/components/common/user-card'
 import { Card, CardAction, CardContent } from '@/components/shadcn/card'
-import { initHistoryAndLocation } from '@/lib/utils'
 import MyPageLayout from '@/components/my-page-screen/my-page-layout'
 import { authStore } from '@/store/auth-store'
 import { useNavigate } from '@tanstack/react-router'
@@ -64,7 +63,7 @@ function MyPage() {
             }
             authStore.getState().initAccessToken()
             queryClient.clear()
-            initHistoryAndLocation()
+            navigate({ to: '/' })
           },
         },
       ],

--- a/src/routes/my-page/withdraw.tsx
+++ b/src/routes/my-page/withdraw.tsx
@@ -7,10 +7,9 @@ import ConfirmDialog from '@/components/common/modal/confirm-dialog'
 import { useRef, useState } from 'react'
 import ResultNoticeDialog from '@/components/common/modal/notice-dialog'
 import { usersApi } from '@/api/users'
-import { initHistoryAndLocation } from '@/lib/utils'
 import { toast } from 'sonner'
 import { Button } from '@/components/common/button'
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { WithDrawnFormState } from '@/types/withdraw'
 import { useMutation } from '@tanstack/react-query'
 import { showMessageIfExists } from '@/lib/error'
@@ -24,6 +23,7 @@ function WithDraw() {
   const [showNoticeModal, setShowNoticeModal] = useState(false)
   const [cautionIsChecked, setCautionIsChecked] = useState(false)
   const dataRef = useRef<WithDrawnFormState | null>(null)
+  const navigate = useNavigate()
 
   const { register, handleSubmit } = useForm<WithDrawnFormState>()
 
@@ -91,7 +91,7 @@ function WithDraw() {
           setIsOpen={setShowNoticeModal}
           description={`회원 탈퇴가\n정상적으로 완료되었습니다.`}
           onConfirm={() => {
-            initHistoryAndLocation()
+            navigate({ to: '/' })
             setShowNoticeModal(false)
           }}
         />

--- a/src/routes/signup.tsx
+++ b/src/routes/signup.tsx
@@ -1,11 +1,10 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { usersApi } from '@/api/users'
 import AppTitle from '@/components/common/app-title'
 import InputProfileImage from '@/components/common/input-profile-image'
 import PageLayOut from '@/components/common/page-layout'
 import InputNickname from '@/components/edit-profile-screen/nickname-checkt-input/input-nickname'
 import { Button } from '@/components/common/button'
-import { initHistoryAndLocation } from '@/lib/utils'
 import { useState } from 'react'
 import { Controller, SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
@@ -30,6 +29,7 @@ function Signup() {
   const search = Route.useSearch()
   const tempToken = search?.tempToken
   const setAccessToken = authStore((s) => s.setAccessToken)
+  const navigate = useNavigate()
 
   if (!tempToken) {
     throw new Error('Invalid tempToken')
@@ -42,7 +42,7 @@ function Signup() {
     },
   })
 
-  const onSubmit: SubmitHandler<FormState> = (data) => {
+  const onSubmit: SubmitHandler<FormState> = async (data) => {
     if (!data.nickname) {
       toast.error('닉네임을 입력해주세요.')
       return
@@ -61,7 +61,7 @@ function Signup() {
       return
     }
 
-    usersApi
+    await usersApi
       .signup({
         tempToken,
         nickname: data.nickname,
@@ -75,7 +75,7 @@ function Signup() {
         }
       })
       .then(() => {
-        initHistoryAndLocation()
+        navigate({ to: '/' })
       })
       .catch((err) => {
         showMessageIfExists(err)


### PR DESCRIPTION
## 🔗 관련 이슈 : 

## 📌 개요

<!-- 이 PR에서 어떤 작업을 했는지 간단하게 요약해주세요. -->
<!-- - ex) 마이페이지 > 포인트 필터 기능 퍼블리싱 완료 -->
initHistoryAndLocation를 호출해도 뒤로가기 버튼이 어쨌든 동작하고,
스택 클리어 하는 방법은 정말 없는 것 같아서
initHistoryAndLocation 함수 자체를 제거 했습니다. 전부 navigate 함수를 호출하는걸로 대체했습니다.

## 🔍 작업 유형

- [x] 기능 추가 (feat)

## 🧩 작업 상세

<!-- 작업한 내용을 상세히 설명해주세요. 왜 이런 구현을 했는지도 적어주세요. -->

<!-- - ex) `DialogContent` 하단 고정되도록 `translate-y-0` 적용 -->

## 🖼️ 화면 스크린샷 (Optional)

<!-- UI 변경 사항이 있을 경우 스크린샷 첨부해주세요. -->

## 💬 리뷰 요구사항 (Optional)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요. -->
