### PR TITLE
fix: add formState.dirtyFields.nickname in line61

### DIFF
--- a/src/components/edit-profile-screen/edit-profile-form.tsx
+++ b/src/components/edit-profile-screen/edit-profile-form.tsx
@@ -42,11 +42,13 @@ function EditProfileForm() {
   }, [me, reset])
 
   const onSubmit: SubmitHandler<FormState> = (data) => {
+    // 1. 보낼 데이터가 없는 경우
     if (!data.profileImage && !data.nickname) {
       toast.error('닉네임을 입력해 주세요.')
       return
     }
 
+    // 2. 닉네임 중복된 경우
     if (isNicknameDuplicated) {
       // diabled로 설정되어 form 제출 불가능
       toast.error(
@@ -55,7 +57,8 @@ function EditProfileForm() {
       return
     }
 
-    if (!hasTriedDuplicateCheck) {
+    // 3. 닉네임 input을 건드렸으나, 중복확인을 안한 경우 -> 이미지만 변경 가능하게 하기 위함
+    if (formState.dirtyFields.nickname && !hasTriedDuplicateCheck) {
       toast.error('닉네임 중복확인을 해주세요')
       return
     }


### PR DESCRIPTION
## 🔗 관련 이슈 : #276 

## 📌 개요
이미지만 수정이 불가능한 문제 개선 작업입니다.

## 🔍 작업 유형
- [ ] 기능 추가 (feat)
- [x] 버그 수정 (fix) <!-- 엔드 유저를 위한 버그 픽스, 필드스크립트 등 개발자를 위한 버그 픽스는 포함 X -->
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 코드 포맷팅 (style) <!-- 세미콜론, 들여쓰기, 공백 등 (프로덕션 코드 변경사항 X) -->
- [ ] 그 외 잡일 (chore) <!-- 패키지 설치, 개발도구 설정 등 (프로덕션 코드 변경사항 X) -->
- [ ] 테스트 코드 추가 또는 수정 (test)
- [ ] CI/CD (ci)

## 🧩 작업 상세
기존에는 onSubmit 마지막 조건문이 !hasTriedDuplicateCheck만 체크하고 있어서,
👉 사용자가 닉네임을 바꾸려는 게 아니라 프로필 이미지만 변경하려는 경우에도
"닉네임 중복확인을 해주세요"라는 에러 토스트가 뜨는 문제가 있었습니다.

이를 해결하기 위해 formState.dirtyFields.nickname를 조건에 추가하여,
👉 닉네임 입력란을 실제로 수정했을 때만 “닉네임 변경을 원한다”라고 인식하도록 바꿨습니다.